### PR TITLE
Update Forwarder to work alongside helm chart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ RUN apk update && \
     apk add --no-cache gcc musl-dev linux-headers libffi-dev libressl-dev make g++
 
 # Create a group and user
-RUN addgroup -S uwsgi && adduser -S uwsgi -G uwsgi
-RUN pip install --disable-pip-version-check uwsgi
+RUN addgroup -S funcx && adduser -S funcx -G funcx
 WORKDIR /opt/funcx-forwarder
 COPY requirements.txt .
 RUN pip install -r requirements.txt
@@ -13,9 +12,9 @@ RUN pip install -r requirements.txt
 COPY . /opt/funcx-forwarder
 RUN pip install .
 
-USER uwsgi
-WORKDIR /home/uwsgi
+USER funcx
+WORKDIR /home/funcx
 EXPOSE 55000-56000
 EXPOSE 3031
-CMD sh entrypoint.sh
+ENTRYPOINT sh /opt/funcx-forwarder/entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,15 +6,15 @@ RUN apk update && \
 # Create a group and user
 RUN addgroup -S uwsgi && adduser -S uwsgi -G uwsgi
 RUN pip install --disable-pip-version-check uwsgi
-
 WORKDIR /opt/funcx-forwarder
-
 COPY requirements.txt .
-RUN pip install --disable-pip-version-check -q -r ./requirements.txt
+RUN pip install -r requirements.txt
 
 COPY . /opt/funcx-forwarder
+RUN pip install .
 
 USER uwsgi
+WORKDIR /home/uwsgi
 EXPOSE 55000-56000
 EXPOSE 3031
 CMD sh entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,12 @@ RUN apk update && \
 RUN addgroup -S uwsgi && adduser -S uwsgi -G uwsgi
 RUN pip install --disable-pip-version-check uwsgi
 
-COPY . /opt/funcx-forwarder
 WORKDIR /opt/funcx-forwarder
+
+COPY requirements.txt .
 RUN pip install --disable-pip-version-check -q -r ./requirements.txt
-ENV PYTHONPATH "${PYTHONPATH}:/opt/funcx-forwarder"
+
+COPY . /opt/funcx-forwarder
 
 USER uwsgi
 EXPOSE 55000-56000

--- a/README.rst
+++ b/README.rst
@@ -79,3 +79,10 @@ Now, you can start the forwarder service for testing:
 >>> forwarder-service --address 127.0.0.1 --port 50005 --debug
 
 Once you have this running, we can update the endpoint configs to point to this local service.
+
+Docker Container
+================
+
+You can run the service inside a docker container.
+
+>> docker run --rm -it -p 8080:8080 -e "REDIS_HOST=localhost" -e "REDIS_PORT=6123" funcx/forwarder:dev

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,2 @@
-pip install -q -e .
-#[ -d "/funcx" ] && pip install -q -e /funcx
+#!/bin/bash
 uwsgi --ini funcx_forwarder.ini

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-uwsgi --ini funcx_forwarder.ini
+echo "Starting Forwarder against REDIS server $REDIS_HOST : $REDIS_PORT"
+forwarder-service -a 0.0.0.0 -p 8080 --redishost $REDIS_HOST --redisport $REDIS_PORT
+

--- a/funcx_forwarder.ini
+++ b/funcx_forwarder.ini
@@ -3,7 +3,7 @@ uid = uwsgi
 binary-path = /usr/local/bin/uwsgi
 plugins = python37
 protocol = uwsgi
-socket = 0.0.0.0:3031
+http = 0.0.0.0:3031
 manage-script-name = true
 module = funcx_forwarder.service:app
 

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -171,7 +171,7 @@ def cli():
 
     try:
         print("Starting forwarder service")
-        app.run(host='0.0.0.0', port=int(args.port), debug=True)
+        app.run(host=args.address, port=int(args.port), debug=True)
 
     except Exception as e:
         # This doesn't do anything

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         "Function Serving"
     ],
     entry_points={'console_scripts':
-                  ['forwarder-service=forwarder.service:cli',
+                  ['forwarder-service=funcx_forwarder.service:cli',
                   ]
     },
     author='funcX team',


### PR DESCRIPTION
# Problem
For now it looks like the forwarder needs to run as a bare flask app to allow for the cli to set up the environment. This PR removes uWSGI and configures the Docker entrypoint to run the cli with REDIS configuration brought in via environment variables.

# Approach
1.  Install the code inside a docker image
2. Create a funcx user
3. Update entrypoint.sh to run forwarder-service  
