### PR TITLE
Allow advertised forwarder host to be environment var

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,4 +85,4 @@ Docker Container
 
 You can run the service inside a docker container.
 
->> docker run --rm -it -p 8080:8080 -e "REDIS_HOST=localhost" -e "REDIS_PORT=6123" funcx/forwarder:dev
+>> docker run --rm -it -p 8080:8080  -e "ADVERTISED_FORWARDER_ADDRESS=host.docker.internal" -e "REDIS_HOST=localhost" -e "REDIS_PORT=6123" funcx/forwarder:dev

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Starting Forwarder against REDIS server $REDIS_HOST : $REDIS_PORT"
-forwarder-service -a 0.0.0.0 -p 8080 --redishost $REDIS_HOST --redisport $REDIS_PORT
+forwarder-service -a $ADVERTISED_FORWARDER_ADDRESS -p 8080 --redishost $REDIS_HOST --redisport $REDIS_PORT
 

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -171,7 +171,7 @@ def cli():
 
     try:
         print("Starting forwarder service")
-        app.run(host=args.address, port=int(args.port), debug=True)
+        app.run(host="0.0.0.0", port=int(args.port), debug=True)
 
     except Exception as e:
         # This doesn't do anything


### PR DESCRIPTION
# Problem 
The forwarder needs to be able to pass an advertised address to the endpoints. 

# Approach
Add a new environment var to the entry point script
