### PR TITLE
add funcx-endpoint dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ RUN addgroup -S funcx && adduser -S funcx -G funcx
 WORKDIR /opt/funcx-forwarder
 
 RUN pip install -U pip
-RUN pip install "git+https://github.com/funcx-faas/funcX.git@forwarder_rearch_1#egg=funcx&subdirectory=funcx_sdk"
-RUN pip install "git+https://github.com/funcx-faas/funcX.git@forwarder_rearch_1#egg=funcx_endpoint&subdirectory=funcx_endpoint"
-RUN python3 -c "import funcx_endpoint; print(funcx_endpoint.__version__)"
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ parsl>=1.0.0
 configobj==5.0.6
 texttable==1.6.2
 redis==3.5.3
-funcx>=0.0.6a1
+funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk
+funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint
 pyzmq>=19.0.0,<20.0.0
 


### PR DESCRIPTION
funcx-forwarder uses funcx_endpoint. funcx-web-service build is broken without this.