### PR TITLE
Fix boolean logic if task_group_id does not exist

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -400,7 +400,7 @@ class Forwarder(Process):
                 task.completion_time = time.time()
 
             task_group_id = task.task_group_id
-            if 'result' in message or 'exception' in message and task_group_id:
+            if ('result' in message or 'exception' in message) and task_group_id:
 
                 connection = pika.BlockingConnection(self.rabbitmq_conn_params)
                 channel = connection.channel()


### PR DESCRIPTION
Fixes https://github.com/funcx-faas/funcx-forwarder/issues/16

Boolean logic here was incorrect and was getting messed up if a redis Task did not have task_group_id. Ideally, we should've flushed redis to prevent this but the logic should still be fixed here