### PR TITLE
change task transition to log type field

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -302,7 +302,7 @@ class Forwarder(Process):
             "function_id": task.function_id,
             "endpoint_id": task.endpoint,
             "container_id": task.container,
-            "task_transition": True
+            "type": "task_transition"
         }
         logger.info(transition_name, extra=extra_logging)
 

--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -302,7 +302,7 @@ class Forwarder(Process):
             "function_id": task.function_id,
             "endpoint_id": task.endpoint,
             "container_id": task.container,
-            "type": "task_transition"
+            "log_type": "task_transition"
         }
         logger.info(transition_name, extra=extra_logging)
 


### PR DESCRIPTION
We should instead have a general "type" field in the json logs to specify what type of message is being logged when it is a special type