### PR TITLE
Fixes f-string formatting in logs and forwarder shutdown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,26 @@ Once you have this running, we can update the endpoint configs to point to this 
 Docker Container
 ================
 
-You can run the service inside a docker container.
+You can run the service inside a docker container. To build the container locally:
 
->> docker run --rm -it -p 8080:8080  -e "ADVERTISED_FORWARDER_ADDRESS=host.docker.internal" -e "REDIS_HOST=localhost" -e "REDIS_PORT=6123" funcx/forwarder:dev
+.. code-block:: bash
+
+    docker build -t funcx/forwarder:dev .
+
+Then, run the container:
+
+.. code-block:: bash
+
+    # Assumes that Redis and RabbitMQ are running locally in a container
+    docker run --rm -it -p 8080:8080 \
+      -e "ADVERTISED_FORWARDER_ADDRESS=host.docker.internal" \
+      -e "REDIS_HOST=host.docker.internal" \
+      -e "REDIS_PORT=6379" \
+      -e "FUNCX_RABBITMQ_SERVICE_HOST=host.docker.internal" \
+      funcx/forwarder:dev
+
+Once it's running, you can hit the forwarder's endpoints:
+
+.. code-block:: bash
+
+    curl http://localhost:8080/version

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -249,7 +249,7 @@ def cli_run():
     finally:
         logger.debug("Graceful exit")
         app.config['forwarder_command'].put({'command': 'TERMINATE'})
-        fw.stop()
+        fw.terminate()
 
 
 if __name__ == '__main__':

--- a/funcx_forwarder/taskqueue.py
+++ b/funcx_forwarder/taskqueue.py
@@ -82,8 +82,8 @@ class TaskQueue(object):
         self.poller.register(self.zmq_socket, zmq.POLLOUT)
         self.poller.register(self.zmq_socket, zmq.POLLIN)
         os.makedirs(self.keys_dir, exist_ok=True)
-        logger.info("Client key store is at {os.path.abspath(self.keys_dir)}")
-        logger.info("Initialized Taskqueue:{self.mode} on port:{self.port}")
+        logger.info(f"Client key store is at {os.path.abspath(self.keys_dir)}")
+        logger.info(f"Initialized Taskqueue:{self.mode} on port:{self.port}")
 
     def zmq_context(self):
         return self.context


### PR DESCRIPTION
This PR adds fixes to f-strings in logging messages and handles the graceful termination of the Forwarder when started via the CLI and `CTRL-C`'d. Unfortunately, the changes are a little harder to parse since my autoformatters (black and isort) did their work when I saved the file. If there's is a preference for that to not be the case let me know and I can back out the formatting changes.

The other changes of substance here are updates to the README to detail building and running the forwarder as a container.

[ch9657]