### PR TITLE
Log endpoint connects/disconnects and put endpoint status message in JSON

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -372,10 +372,15 @@ class Forwarder(Process):
                 logger.exception(f"Failed to unpickle message from results_q, message:{b_message}")
 
             if isinstance(message, EPStatusReport):
-                logger.debug(f"Endpoint status message {message.__dict__} from {b_ep_id.decode('utf-8')}")
+                endpoint_id = b_ep_id.decode('utf-8')
+                logger.debug("endpoint_status_message", extra={
+                    "log_type": "endpoint_status_message",
+                    "endpoint_id": endpoint_id,
+                    "endpoint_status_message": message.__dict__
+                })
                 # Update endpoint status
                 try:
-                    self.endpoint_db.put(b_ep_id.decode('utf-8'), message.ep_status)
+                    self.endpoint_db.put(endpoint_id, message.ep_status)
                 except Exception:
                     logger.error("Caught error while trying to push endpoint status data into redis")
 

--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -269,7 +269,10 @@ class Forwarder(Process):
         logger.info("Heartbeat")
         dest_endpoint_list = list(self.connected_endpoints.keys())
         for dest_endpoint in dest_endpoint_list:
-            logger.debug(f"Sending heartbeat to {dest_endpoint}")
+            logger.debug(f"Sending heartbeat to {dest_endpoint}", extra={
+                "log_type": "endpoint_heartbeat",
+                "endpoint_id": dest_endpoint
+            })
             msg = Heartbeat(endpoint_id=dest_endpoint)
             try:
                 self.tasks_q.put(dest_endpoint.encode('utf-8'),

--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -189,6 +189,11 @@ class Forwarder(Process):
         Registering an existing endpoint_id is allowed
         """
         logger.info(f"Endpoint_id:{endpoint_id} added to registry")
+        logger.info("endpoint_connected", extra={
+            "log_type": "endpoint_connected",
+            "endpoint_id": endpoint_id
+        })
+
         self.endpoint_registry[endpoint_id] = {'creation_time': time.time(),
                                                'client_public_key': key}
         self.update_endpoint_metadata(endpoint_id, endpoint_address)
@@ -236,6 +241,11 @@ class Forwarder(Process):
         will work on WAN networks with latencies.
         """
         logger.debug(f"Unregistering endpoint: {endpoint_id}")
+        logger.info("endpoint_disconnected", extra={
+            "log_type": "endpoint_disconnected",
+            "endpoint_id": endpoint_id
+        })
+
         self.redis_pubsub.unsubscribe(endpoint_id)
         # TODO: YADU Combine the registry with connected_endpoints
         self.endpoint_registry.pop(endpoint_id, None)

--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -53,8 +53,8 @@ class Forwarder(Process):
                        +-------------+     +--------------------+
                        |  Endpoint 1 | ... |     Endpoint N     |
                        +-------------+     +--------------------+
-    
-    
+
+
     Endpoint States
     ---------------
     - Registered: Endpoint has been registered with the service but has not yet connected
@@ -175,8 +175,8 @@ class Forwarder(Process):
                 elif command['command'] == 'REGISTER_ENDPOINT':
                     logger.info("[COMMAND] Received REGISTER_ENDPOINT command")
                     result = self.register_endpoint(command['endpoint_id'],
-                                                           command['endpoint_address'],
-                                                           command['client_public_key'])
+                                                    command['endpoint_address'],
+                                                    command['client_public_key'])
 
                     response = {'response': result,
                                 'id': command.get('id'),

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -133,14 +133,21 @@ def register():
     2. Pass connection info back as a json response.
     """
     reg_info = request.get_json()
-    logger.debug(f"Registering endpoint : {reg_info['endpoint_id']}")
+    endpoint_id = reg_info['endpoint_id']
+    logger.debug(f"Registering endpoint : {endpoint_id}", extra={
+        "log_type": "forwarder_endpoint_registration_start",
+        "endpoint_id": endpoint_id
+    })
     app.config['forwarder_command'].put({'command': 'REGISTER_ENDPOINT',
                                          'endpoint_id': reg_info['endpoint_id'],
                                          'endpoint_address': reg_info['endpoint_addr'],
                                          'client_public_key': reg_info.get('client_public_key', None),
                                          'id': 0})
     ret_package = app.config['forwarder_response'].get()
-    logger.debug(f"Registration response : {ret_package}")
+    logger.debug("forwarder_endpoint_registration_response", extra={
+        "log_type": "forwarder_endpoint_registration_response",
+        "registration_response": ret_package
+    })
     return ret_package
 
 

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -134,7 +134,7 @@ def register():
     """
     reg_info = request.get_json()
     logger.debug(f"Registering endpoint : {reg_info['endpoint_id']}")
-    app.config['forwarder_command'].put({'command': 'ADD_ENDPOINT_TO_REGISTRY',
+    app.config['forwarder_command'].put({'command': 'REGISTER_ENDPOINT',
                                          'endpoint_id': reg_info['endpoint_id'],
                                          'endpoint_address': reg_info['endpoint_addr'],
                                          'client_public_key': reg_info.get('client_public_key', None),
@@ -224,7 +224,7 @@ def cli_run():
     with open('/tmp/client.key') as f:
         client_key = f.read()
     print("Pushing client key : ", client_key)
-    app.config['forwarder_command'].put({'command' : 'ADD_ENDPOINT_TO_REGISTRY',
+    app.config['forwarder_command'].put({'command' : 'REGISTER_ENDPOINT',
                                          'endpoint_id': 'edb1ebd4-f99a-4f99-b8aa-688da5b5ede7',
                                          'client_public_key': client_key,
                                          'id': 0})


### PR DESCRIPTION
A few useful additions for JSON log monitoring

Should we call it "endpoint_connected"/"endpoint_disconnected" or "endpoint_registered"/"endpoint_unregistered"?