### PR TITLE
[ch9582] Adding external rabbitmq host configuration

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,10 @@ if [[ -z "${REDIS_HOST}" ]]; then
     REDIS_HOST="$FUNCX_REDIS_MASTER_SERVICE_HOST"
 fi
 
+if [[ -z "${RABBITMQ_HOST}" ]]; then
+    RABBITMQ_HOST="$FUNCX_RABBITMQ_SERVICE_HOST"
+fi
+
 python3 wait_for_redis.py
 
 if [[ -z "${ADVERTISED_FORWARDER_ADDRESS}" ]]; then
@@ -17,5 +21,5 @@ if [[ -z "${ADVERTISED_FORWARDER_ADDRESS}" ]]; then
     ADVERTISED_FORWARDER_ADDRESS=`wget http://169.254.169.254/latest/meta-data/public-ipv4; cat public-ipv4`
 fi
 
-forwarder-service -a $ADVERTISED_FORWARDER_ADDRESS -p 8080 --redishost $REDIS_HOST --redisport $REDIS_PORT --rabbitmqhost $FUNCX_RABBITMQ_SERVICE_HOST -d
+forwarder-service -a $ADVERTISED_FORWARDER_ADDRESS -p 8080 --redishost $REDIS_HOST --redisport $REDIS_PORT --rabbitmqhost $RABBITMQ_HOST -d
 


### PR DESCRIPTION
This change is needed in the forwarder before it will pickup an external rabbitmq host.

[ch9582]