### PR TITLE
Fix redis churn and reconsider state issues

### DIFF
--- a/funcx_forwarder/queues/redis/redis_pubsub.py
+++ b/funcx_forwarder/queues/redis/redis_pubsub.py
@@ -100,7 +100,8 @@ class RedisPubSub(object):
 
     def unsubscribe(self, endpoint_id):
         self.pubsub.unsubscribe(self.channel_name(endpoint_id))
-        self.subscriber_count -= 1
+        if self.subscriber_count > 0:
+            self.subscriber_count -= 1
 
     def get(self, timeout: int = 2) -> Tuple[str, Task]:
         """


### PR DESCRIPTION
The redis churn issue is a race condition in which the ~~forwarder~~ endpoint is stopped then started a short period after. The broken state transition is CONNECTED -> REGISTERED -> DISCONNECTED -> CONNECTED

It can be reproduced like so:
- Write down the exact time in seconds when a heartbeat is sent to a running endpoint (they go out every 30s)
- Stop the endpoint directly after this heartbeat
- Start the endpoint again around 27s after the heartbeat - The result is that the previous endpoint ZMQ connection is disconnected in between the registration and connection points of the new endpoint (There is about a 6 second difference between these 2 points usually)
- Send a task, and the redis churn will start

We have to do some careful thinking about when transitions should be allowed to happen. This is all complicated by the fact that it is difficult to forcefully remove a ZMQ socket connection from the forwarder