### PR TITLE
Adding config option to set zmq ports

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,10 @@ if [[ -z "${RABBITMQ_HOST}" ]]; then
     RABBITMQ_HOST="$FUNCX_RABBITMQ_SERVICE_HOST"
 fi
 
+if [[ -z "${ENDPOINT_BASE_PORT}" ]]; then
+    ENDPOINT_BASE_PORT=50001
+fi
+
 python3 wait_for_redis.py
 
 if [[ -z "${ADVERTISED_FORWARDER_ADDRESS}" ]]; then
@@ -21,5 +25,5 @@ if [[ -z "${ADVERTISED_FORWARDER_ADDRESS}" ]]; then
     ADVERTISED_FORWARDER_ADDRESS=`wget http://169.254.169.254/latest/meta-data/public-ipv4; cat public-ipv4`
 fi
 
-forwarder-service -a $ADVERTISED_FORWARDER_ADDRESS -p 8080 --redishost $REDIS_HOST --redisport $REDIS_PORT --rabbitmqhost $RABBITMQ_HOST -d
+forwarder-service -a $ADVERTISED_FORWARDER_ADDRESS -p 8080 --redishost $REDIS_HOST --redisport $REDIS_PORT --rabbitmqhost $RABBITMQ_HOST -d --endpoint-base-port ${ENDPOINT_BASE_PORT}
 

--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -89,7 +89,7 @@ class Forwarder(Process):
                  response_queue,
                  address: str,
                  redis_address: str,
-                 rabbitmq_conn_params: str,
+                 rabbitmq_conn_params,
                  endpoint_ports=(55001, 55002, 55003),
                  redis_port: int = 6379,
                  logging_level=logging.INFO,

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -182,6 +182,16 @@ def cli_run():
                         help="Enables debug logging")
     parser.add_argument("-v", "--version", action='store_true',
                         help="Print version information")
+    parser.add_argument(
+        "--endpoint-base-port",
+        default=50001,
+        type=int,
+        help=(
+            "The base port for zmq channels.  The forwarder "
+            "will reserve three port numbers starting at this "
+            "port number and the next two higher."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -214,7 +224,7 @@ def cli_run():
                    args.address,
                    args.redishost,
                    rabbitmq_conn_params,
-                   # endpoint_ports=(55008, 55009, 55010),   # Only for debug
+                   endpoint_ports=range(args.endpoint_base_port, args.endpoint_base_port + 3),
                    logging_level=logging_level,
                    redis_port=args.redisport)
     fw.start()


### PR DESCRIPTION
This is the forwarder side of [ch9611] to allow configuring zmq ports for dev deploys.