### PR TITLE
Pull in funcx-common for RedisField system

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -9,14 +9,16 @@ import funcx_forwarder
 
 
 from multiprocessing import Process, Queue, Event
+from funcx_common.tasks import TaskState
+
 from funcx_forwarder.taskqueue import TaskQueue
 from funcx_forwarder.queues.redis.redis_pubsub import RedisPubSub
 from funcx_forwarder.endpoint_db import EndpointDB
 
 from funcx_endpoint.executors.high_throughput.messages import Task, Heartbeat, EPStatusReport, ResultsAck
 
-from funcx_forwarder.queues.redis.tasks import Task as RedisTask
-from funcx_forwarder.queues.redis.tasks import TaskState, status_code_convert
+from funcx_forwarder.queues.redis.tasks import RedisTask, status_code_convert
+
 import time
 import pickle
 import pika

--- a/funcx_forwarder/queues/redis/redis_pubsub.py
+++ b/funcx_forwarder/queues/redis/redis_pubsub.py
@@ -1,10 +1,12 @@
-import redis
-from redis.exceptions import ConnectionError
 import queue
 from typing import Tuple
-from funcx_forwarder.errors import FuncxError
-from funcx_forwarder.queues.redis.tasks import Task, TaskState
 import logging
+
+from funcx_common.tasks import TaskState
+import redis
+
+from funcx_forwarder.errors import FuncxError
+from funcx_forwarder.queues.redis.tasks import RedisTask
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +46,7 @@ class RedisPubSub(object):
         try:
             self.redis_client = redis.StrictRedis(host=self.hostname, port=self.port, decode_responses=True)
             self.redis_client.ping()
-        except ConnectionError:
+        except redis.exceptions.ConnectionError:
             logger.exception("ConnectionError while trying to connect to Redis@{}:{}".format(
                 self.hostname,
                 self.port))
@@ -66,7 +68,7 @@ class RedisPubSub(object):
             raise Exception("Not connected")
             raise NotConnected(self)
 
-        except ConnectionError:
+        except redis.exceptions.ConnectionError:
             logger.exception("ConnectionError while trying to connect to Redis@{}:{}".format(
                 self.hostname,
                 self.port))
@@ -122,7 +124,7 @@ class RedisPubSub(object):
             # Strip channel prefix
             dest_endpoint = package['channel'][self._task_channel_prefix_len:]
             task_id = package['data']
-            task = Task.from_id(self.redis_client, task_id)
+            task = RedisTask.from_id(self.redis_client, task_id)
 
         except queue.Empty:
             raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ parsl>=1.1.0a0
 configobj==5.0.6
 texttable==1.6.2
 redis==3.5.3
+funcx-common[redis]==0.0.4
 funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk
 funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint
 pyzmq==22.0.3


### PR DESCRIPTION
RedisTask (a rename of `Task`) is defined using funcx-common RedisField utilities.

RedisField uses the owning object's `redis_client`, rather than `rc`, but is otherwise almost identical to the pre-existing code. The RedisTask class has been subjected to some cleanup, but no drastic changes.

The `TaskState` enum is also provided by `funcx_common.tasks`.