### PR TITLE
Reliable Results Ack Handling

### DIFF
--- a/funcx_forwarder/queues/redis/tasks.py
+++ b/funcx_forwarder/queues/redis/tasks.py
@@ -16,6 +16,7 @@ class TaskState(str, Enum):
     RUNNING = "running"
     SUCCESS = "success"
     FAILED = "failed"
+    PARTIAL = "partial"  # in the process of being sent over RabbitMQ and saved to redis (intermediate state)
 
 
 def status_code_convert(code):


### PR DESCRIPTION
This PR is meant to make potential issues with redis/rabbitmq resolvable via partial states before sending the ack.