### PR TITLE
Forwarder should support specific ports in helm values

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,9 +26,9 @@ Response payload::
 
   {
      'endpoint_id': endpoint_id,
-     'task_url': 'tcp://55.77.66.22:50001',
-     'result_url': 'tcp://55.77.66.22:50002',
-     'command_port': 'tcp://55.77.66.22:50003'
+     'task_url': 'tcp://55.77.66.22:55001',
+     'result_url': 'tcp://55.77.66.22:55002',
+     'command_port': 'tcp://55.77.66.22:55003'
   }
 
 /list_endpoints

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ if [[ -z "${RABBITMQ_URI}" ]]; then
 fi
 
 if [[ -z "${ENDPOINT_BASE_PORT}" ]]; then
-    ENDPOINT_BASE_PORT=50001
+    ENDPOINT_BASE_PORT=55001
 fi
 
 python3 wait_for_redis.py

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -184,7 +184,7 @@ def cli_run():
                         help="Print version information")
     parser.add_argument(
         "--endpoint-base-port",
-        default=50001,
+        default=55001,
         type=int,
         help=(
             "The base port for zmq channels.  The forwarder "


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/funcx-faas/funcx-forwarder/commit/8fbe74291bd87985a23470fe395950203a0b4f41 where the wrong port is defaulted to.
Story details: https://app.shortcut.com/funcx/story/9611