### PR TITLE
Reliable Results Ack

### DIFF
--- a/funcx_forwarder/queues/redis/redis_pubsub.py
+++ b/funcx_forwarder/queues/redis/redis_pubsub.py
@@ -3,7 +3,7 @@ from redis.exceptions import ConnectionError
 import queue
 from typing import Tuple
 from funcx_forwarder.errors import FuncxError
-from funcx_forwarder.queues.redis.tasks import Task, TaskState
+from funcx_forwarder.queues.redis.tasks import Task, InternalTaskState, TaskState
 import logging
 
 logger = logging.getLogger(__name__)
@@ -57,6 +57,7 @@ class RedisPubSub(object):
         try:
             task.endpoint = endpoint_id
             task.status = TaskState.WAITING_FOR_EP
+            task.internal_status = InternalTaskState.INCOMPLETE
             # Note: Task object is already in Redis
             subscribers = self.redis_client.publish(self.channel_name(endpoint_id), task.task_id)
             if subscribers == 0:

--- a/funcx_forwarder/queues/redis/tasks.py
+++ b/funcx_forwarder/queues/redis/tasks.py
@@ -18,6 +18,13 @@ class TaskState(str, Enum):
     FAILED = "failed"
 
 
+# This internal state is never shown to the user and is meant to track whether
+# or not the forwarder has succeeded in fully processing the task
+class InternalTaskState(str, Enum):
+    INCOMPLETE = "incomplete"
+    COMPLETE = "complete"
+
+
 def status_code_convert(code):
     return {
         TaskStatusCode.WAITING_FOR_NODES: TaskState.WAITING_FOR_NODES,
@@ -75,6 +82,7 @@ class Task:
     ORM-esque class to wrap access to properties of tasks for better style and encapsulation
     """
     status = RedisField(serializer=lambda ts: ts.value, deserializer=TaskState)
+    internal_status = RedisField(serializer=lambda ts: ts.value, deserializer=InternalTaskState)
     user_id = RedisField(serializer=str, deserializer=int)
     function_id = RedisField()
     endpoint = RedisField()


### PR DESCRIPTION
The main changes here are:

- A new internal task state that is only meant to track whether the forwarder has successfully finished processing a task
- Reorganization of final task processing when a result arrives on the forwarder

Corresponding web service PR: https://github.com/funcx-faas/funcx-web-service/pull/251
Also relevant: https://github.com/funcx-faas/funcX/pull/590 (because these changes can lead to a task_id being put on RabbitMQ multiple times, meaning it gets sent over WebSocket multiple times to user)