### PR TITLE
Backwards compatability: Conditionally send ack based on EP version

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -555,6 +555,7 @@ class Forwarder(Process):
                 "task_id": task_id
             })
 
+        # TODO: remove once endpoint version 0.3.* is deprecated
         reg_message = self.connected_endpoints[endpoint_id]['registration_message']
         # if the key funcx_endpoint_version is in the registration message, it means
         # the endpoint version is >=0.3.3, because 0.3.3 is the first endpoint version


### PR DESCRIPTION
Corresponding PR: https://github.com/funcx-faas/funcX/pull/592

An Ack should only be sent if the endpoint version is >=0.3.3

Any endpoint version below that does not send its version to the forwarder at all, so we can deduce that it is <0.3.3