### PR TITLE
Prevent redis churn due to broken redis Task

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -401,7 +401,7 @@ class Forwarder(Process):
             except TypeError:
                 # A TypeError is raised when the Task object can't be recomposed from REDIS
                 # due to missing values during high-workload events.
-                logger.exception(f"[CRITICAL] Unable to access task {task_id} from redis")
+                logger.exception(f"Unable to access task {task_id} from redis")
                 logger.debug(f"Task:{task_id} is now LOST", extra={
                     "log_type": "task_lost",
                     "endpoint_id": dest_endpoint,

--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -398,9 +398,15 @@ class Forwarder(Process):
                 zmq_task = Task(task_id,
                                 task.container,
                                 task.payload)
-            except Exception:
+            except TypeError:
+                # A TypeError is raised when the Task object can't be recomposed from REDIS
+                # due to missing values during high-workload events.
                 logger.exception(f"[CRITICAL] Unable to access task {task_id} from redis")
-                # TODO: log that task transitioned to lost
+                logger.debug(f"Task:{task_id} is now LOST", extra={
+                    "log_type": "task_lost",
+                    "endpoint_id": dest_endpoint,
+                    "task_id": task_id
+                })
                 return 0
 
             try:


### PR DESCRIPTION
Create a new try block that does NOT put the task back in redis pubsub if a redis task property access fails, as this will lead to redis churn that spams the forwarder logs