### PR TITLE
Use TaskStorage from funcx-common

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
       run: pytest
       env:
         REDIS_HOST: redis  # this is the hostname for the service container
+        FUNCX_S3_BUCKET_NAME: BOGUS_BUCKET_NAME  # this is a temporary fix
+        FUNCX_REDIS_STORAGE_THRESHOLD: 512000  # Max storage allowed in redis
 
   publish:
     # only trigger on pushes to the main repo (not forks, and not PRs)

--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -90,8 +90,10 @@ class Forwarder(Process):
                  address: str,
                  redis_address: str,
                  rabbitmq_conn_params,
-                 s3_bucket_name: str = os.environ['S3_BUCKET_NAME'],
-                 redis_storage_threshold: int = int(os.environ.get('REDIS_STORAGE_THRESHOLD', 20000)),
+                 s3_bucket_name: str = os.environ['FUNCX_S3_BUCKET_NAME'],
+                 redis_storage_threshold: int = int(os.environ.get(
+                     'FUNCX_REDIS_STORAGE_THRESHOLD',
+                     20000)),
                  endpoint_ports=(55001, 55002, 55003),
                  redis_port: int = 6379,
                  logging_level=logging.INFO,

--- a/funcx_forwarder/tasks.py
+++ b/funcx_forwarder/tasks.py
@@ -11,7 +11,6 @@ from funcx_common.redis import (
 )
 from funcx_common.tasks import TaskProtocol, TaskState
 from funcx_endpoint.executors.high_throughput.messages import TaskStatusCode
-
 from redis import Redis
 
 
@@ -48,6 +47,7 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
     container = RedisField()
     payload = RedisField(serde=JSON_SERDE)
     result = RedisField()
+    result_reference = RedisField(serde=JSON_SERDE)
     exception = RedisField()
     completion_time = RedisField()
     task_group_id = RedisField()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ parsl>=1.1.0a0
 configobj==5.0.6
 texttable>=1.6.4,<2
 redis==3.5.3
-funcx-common[redis]==0.0.8
+funcx-common[redis]==0.0.9
 funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk
 funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint
 pyzmq==22.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ parsl>=1.1.0a0
 configobj==5.0.6
 texttable>=1.6.4,<2
 redis==3.5.3
-funcx-common[redis]==0.0.9
+funcx-common[redis,boto3]==0.0.9
 funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk
 funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint
 pyzmq==22.0.3


### PR DESCRIPTION
Adds support for storing oversized results in S3 using `funcx_common.task_storage.RedisS3Storage`.

This is configured via env variables to minimize the overhead of modifying a bunch of CLI interfaces:
* `FUNCX_S3_BUCKET_NAME` is now a *required* option consumed by the `Forwarder` from env vars
* `FUNCX_REDIS_STORAGE_THRESHOLD` is optional, and defaults to 20000. This is the char size of a string below which it would be stored in redis.

For this to work, the container must have access to the S3 bucket referenced. I suspect that I'll need @joshbryan-globus 's help on this.

I'll keep this as a draft until I'm done testing.