### PR TITLE
Fix requirements to specify range for semver deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 flask==1.1.2
-requests>=2.24.0
+requests>=2.24.0,<3
 jsonschema==3.2.0
 parsl>=1.1.0a0
 configobj==5.0.6
-texttable==1.6.2
+texttable>=1.6.4,<2
 redis==3.5.3
 funcx-common[redis]==0.0.8
 funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk


### PR DESCRIPTION
Set upper bound on `requests`
Switch `texttable` to a range of versions (up to v2)

[[sc-11641]](https://app.shortcut.com/funcx/story/11641)

---

A docker build with these fixed requirements succeeded for me locally. We'll watch CI as well, to confirm that the fix works as expected.