### PR TITLE
Begin cleaning up "EndpointDB" module

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -145,12 +145,9 @@ class Forwarder(Process):
         self.result_ttl = result_ttl
         # TODO: drop support for imperatively configuring the redis host information
         # for the forwarder. Instead, FUNCX_COMMON_REDIS_URL should be used
-        self.redis_pubsub = FuncxRedisPubSub(
-            redis_client=default_redis_connection_factory(
-                f"redis://{redis_address}:{redis_port}"
-            )
-        )
-        self.endpoint_db = EndpointDB(hostname=redis_address, port=redis_port)
+        redis_client = default_redis_connection_factory(f"redis://{redis_address}:{redis_port}")
+        self.redis_pubsub = FuncxRedisPubSub(redis_client=redis_client)
+        self.endpoint_db = EndpointDB(redis_client=redis_client)
         self.endpoint_db.connect()
 
         logger.info(f"Initializing forwarder v{funcx_forwarder.__version__}")


### PR DESCRIPTION
In order to remove the dependency from the forwarder onto the funcx-endpoint package, cleanup "EndpointDB" to the following basic standards:
- no dead methods
- no bizarre abuse of AttributeError
- client connection is passed in from the outside

In particular, this removes a dependency on `funcx-endpoint` for its (internal) "NotConnected" error class.