### PR TITLE
Fix pubsub `get()` call result handling

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -385,7 +385,8 @@ class Forwarder(Process):
         # Now wait for any messages on REDIS that needs forwarding.
         task = None
         try:
-            dest_endpoint, task = self.redis_pubsub.get(timeout=0)
+            dest_endpoint, task_id = self.redis_pubsub.get(timeout=0)
+            task = RedisTask(self.redis_client, task_id)
             logger.debug(f"Got message from REDIS: {dest_endpoint}:{task}", extra={
                 "log_type": "forwarder_redis_task_get",
                 "endpoint_id": dest_endpoint


### PR DESCRIPTION
The response from `redis_pubsub.get` is a tuple of strings, not a string + RedisTask object. Construct the desired task explicitly.