### PR TITLE
Add pre commit config and get all linting to pass

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+- repo: meta
+  hooks:
+    - id: check-hooks-apply
+    - id: check-useless-excludes
+- repo: https://github.com/pre-commit/pre-commit-hooks.git
+  rev: v4.0.1
+  hooks:
+    - id: check-merge-conflict
+    - id: trailing-whitespace
+- repo: https://github.com/sirosen/check-jsonschema
+  rev: 0.7.1
+  hooks:
+    - id: check-github-workflows
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+    - id: flake8
+      additional_dependencies: ['flake8-bugbear==21.4.3']
+- repo: https://github.com/python/black
+  rev: 21.11b1
+  hooks:
+    - id: black
+- repo: https://github.com/timothycrosley/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.29.1
+  hooks:
+    - id: pyupgrade
+      args: ["--py36-plus"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# CONTRIBUTING
+
+## Tool Requirements
+
+- `make`
+- `tox`
+
+Install `tox` with `pipx install tox`
+
+### Recommended
+
+- `pre-commit`
+- Docker
+
+Install `scriv` and `pre-commit` with
+
+    pipx install scriv
+    pipx install pre-commit
+
+## Linting & Testing
+
+Testing and linting are run under [tox](https://tox.readthedocs.io/en/latest/).
+
+### Running Tests
+
+Tests require a local redis instance to be up and running.
+
+With that in place, run tox:
+
+    tox
+
+### Local Redis in Docker
+
+The easiest way to get a local redis instance is to run a docker container:
+
+.. code-block:: bash
+
+    docker run -d -p 6379:6379 --name funcx-forwarder-test-redis redis
+
+### Optional, but recommended, linting setup
+
+For the best development experience, we recommend setting up linting and
+autofixing integrations with your editor and git.
+
+We use [pre-commit](https://pre-commit.com/) to automatically run linters and fixers.
+Install `pre-commit` and then run
+
+    $ pre-commit install
+
+to setup the hooks.
+
+The configured linters and fixers can be seen in `.pre-commit-config.yaml`.

--- a/README.rst
+++ b/README.rst
@@ -106,30 +106,3 @@ Once it's running, you can hit the forwarder's endpoints:
 .. code-block:: bash
 
     curl http://localhost:8080/version
-
-
-Running Tests
-=============
-
-Tests require a local redis instance to be up and running.
-
-With that in place, install the dev requirements:
-
-.. code-block:: bash
-
-    pip install '.[dev]'
-
-And run pytest:
-
-.. code-block:: bash
-
-    pytest
-
-Local Redis in Docker
----------------------
-
-The easiest way to get a local redis instance is to run a docker container:
-
-.. code-block:: bash
-
-    docker run -d -p 6379:6379 --name funcx-forwarder-test-redis redis

--- a/archived_tests/create_certs.py
+++ b/archived_tests/create_certs.py
@@ -1,27 +1,40 @@
-import zmq.auth
 import argparse
 import os
 
+import zmq.auth
+
 keys_dir = ".curve"
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-f", "--force", action='store_true',
-                        help="Force overwrite if keys already exist")
-    parser.add_argument("-d", "--dir", default='.curve',
-                        help="Directory to which keys should be written.")
+    parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Force overwrite if keys already exist",
+    )
+    parser.add_argument(
+        "-d",
+        "--dir",
+        default=".curve",
+        help="Directory to which keys should be written.",
+    )
     args = parser.parse_args()
 
     os.makedirs(args.dir, exist_ok=True)
 
-    target = os.path.join(args.dir, 'server.key')
+    target = os.path.join(args.dir, "server.key")
     if os.path.exists(target):
         if args.force:
             print(f"Server keys exist at: {target}*, overwriting")
-            server_public_file, server_secret_file = zmq.auth.create_certificates(args.dir, "server")
+            server_public_file, server_secret_file = zmq.auth.create_certificates(
+                args.dir, "server"
+            )
         else:
             print(f"Server keys exist at: {target}*, aborting")
     else:
-        server_public_file, server_secret_file = zmq.auth.create_certificates(args.dir, "server")
+        server_public_file, server_secret_file = zmq.auth.create_certificates(
+            args.dir, "server"
+        )
         print(f"Wrote key to {server_secret_file}")

--- a/archived_tests/test_ep_registration.py
+++ b/archived_tests/test_ep_registration.py
@@ -1,17 +1,19 @@
 import requests
 
-address = 'http://127.0.0.1:8088'
-endpoint_id = 'test_endpoint'
-endpoint_address = 'borgmachine'
-redis_address = '127.0.0.1'
-client_key = 'client_key_string'
+address = "http://127.0.0.1:8088"
+endpoint_id = "test_endpoint"
+endpoint_address = "borgmachine"
+redis_address = "127.0.0.1"
+client_key = "client_key_string"
 
-r = requests.post(address + '/register',
-                  json={'endpoint_id': endpoint_id,
-                        'redis_address': redis_address,
-                        'endpoint_addr': endpoint_address,
-                        'client_key': client_key,
-                  }
+r = requests.post(
+    address + "/register",
+    json={
+        "endpoint_id": endpoint_id,
+        "redis_address": redis_address,
+        "endpoint_addr": endpoint_address,
+        "client_key": client_key,
+    },
 )
 
 print(r)

--- a/archived_tests/test_executor.py
+++ b/archived_tests/test_executor.py
@@ -1,8 +1,9 @@
-from funcx.executors import HighThroughputExecutor as HTEX
-from parsl.providers import LocalProvider
-from parsl.channels import LocalChannel
-from parsl import set_stream_logger
 import time
+
+from funcx.executors import HighThroughputExecutor as HTEX
+from parsl import set_stream_logger
+from parsl.channels import LocalChannel
+from parsl.providers import LocalProvider
 
 
 def double(x):
@@ -13,13 +14,14 @@ if __name__ == "__main__":
 
     set_stream_logger()
 
-    executor = HTEX(label='htex',
-                    provider=LocalProvider(
-                        channel=LocalChannel),
-                    address='34.207.74.221')
+    executor = HTEX(
+        label="htex",
+        provider=LocalProvider(channel=LocalChannel),
+        address="34.207.74.221",
+    )
 
     ports = executor.start()
-    print("Connect on ports {}".format(ports))
+    print(f"Connect on ports {ports}")
 
     print("Submitting")
     fu = executor.submit(double, *[2])

--- a/archived_tests/test_modded_redis.py
+++ b/archived_tests/test_modded_redis.py
@@ -3,12 +3,14 @@ import time
 import uuid
 
 from funcx.serialize import FuncXSerializer
-from funcx_forwarder.queues.redis.tasks import Task, TaskState
+
 from funcx_forwarder.queues.redis.redis_pubsub import RedisPubSub
+from funcx_forwarder.queues.redis.tasks import Task, TaskState
 
 
 def slow_double(i, duration=0):
     import time
+
     time.sleep(duration)
     return i * 2
 
@@ -31,7 +33,7 @@ def dont_run_yet(endpoint_id=None, tasks=10, duration=1, hostname=None):
         task_id = str(uuid.uuid4())
         print("Task_id : ", task_id)
         ser_args = fxs.serialize([i])
-        ser_kwargs = fxs.serialize({'duration': duration})
+        ser_kwargs = fxs.serialize({"duration": duration})
         input_data = fxs.pack_buffers([ser_args, ser_kwargs])
         payload = fn_code + input_data
         container_id = "RAW"
@@ -43,7 +45,7 @@ def dont_run_yet(endpoint_id=None, tasks=10, duration=1, hostname=None):
         task_ids[i] = task_id
 
     d1 = time.time() - start
-    print("Time to launch {} tasks: {:8.3f} s".format(tasks, d1))
+    print(f"Time to launch {tasks} tasks: {d1:8.3f} s")
 
     delay = 5
     print(f"Sleeping {delay} seconds")
@@ -63,24 +65,27 @@ def dont_run_yet(endpoint_id=None, tasks=10, duration=1, hostname=None):
             pass
 
     delta = time.time() - start
-    print("Time to complete {} tasks: {:8.3f} s".format(tasks, delta))
-    print("Throughput : {:8.3f} Tasks/s".format(tasks / delta))
+    print(f"Time to complete {tasks} tasks: {delta:8.3f} s")
+    print(f"Throughput : {tasks / delta:8.3f} Tasks/s")
     return delta
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-r", "--redis_hostname", default='127.0.0.1',
-                        help="Hostname of the Redis server")
-    parser.add_argument("-e", "--endpoint_id", required=True,
-                        help="Endpoint_id")
-    parser.add_argument("-d", "--duration", required=True,
-                        help="Duration of the tasks")
-    parser.add_argument("-c", "--count", required=True,
-                        help="Number of tasks")
+    parser.add_argument(
+        "-r",
+        "--redis_hostname",
+        default="127.0.0.1",
+        help="Hostname of the Redis server",
+    )
+    parser.add_argument("-e", "--endpoint_id", required=True, help="Endpoint_id")
+    parser.add_argument("-d", "--duration", required=True, help="Duration of the tasks")
+    parser.add_argument("-c", "--count", required=True, help="Number of tasks")
 
     args = parser.parse_args()
-    dont_run_yet(endpoint_id=args.endpoint_id,
-                 hostname=args.redis_hostname,
-                 duration=int(args.duration),
-                 tasks=int(args.count))
+    dont_run_yet(
+        endpoint_id=args.endpoint_id,
+        hostname=args.redis_hostname,
+        duration=int(args.duration),
+        tasks=int(args.count),
+    )

--- a/archived_tests/test_redis_pubsub.py
+++ b/archived_tests/test_redis_pubsub.py
@@ -1,13 +1,14 @@
-from funcx_forwarder.queues.redis.redis_pubsub import RedisPubSub
-from funcx_endpoint.executors.high_throughput.messages import Task
 import argparse
 import time
 
+from funcx_endpoint.executors.high_throughput.messages import Task
+
+from funcx_forwarder.queues.redis.redis_pubsub import RedisPubSub
+
 
 def test_client(ep=None):
-    ''' Untested
-    '''
-    receiver = RedisPubSub('127.0.0.1')
+    """Untested"""
+    receiver = RedisPubSub("127.0.0.1")
     receiver.connect()
     receiver.subscribe(ep)
 
@@ -22,7 +23,7 @@ def test_client(ep=None):
             print("Received msg : ", msg)
             if not t:
                 t = time.time()
-            if task == 'sentinel':
+            if task == "sentinel":
                 print("Breaking received sentinel")
                 delta = time.time() - t
                 break
@@ -31,34 +32,47 @@ def test_client(ep=None):
         except Exception:
             pass
 
-    print("Performance : {:8.3f} Msgs/s".format(count / delta))
+    print(f"Performance : {count / delta:8.3f} Msgs/s")
 
 
 def test_server(ep=None, count=1000, delay=0):
-    ''' Untested
-    '''
-    sender = RedisPubSub('127.0.0.1')
+    """Untested"""
+    sender = RedisPubSub("127.0.0.1")
     sender.connect()
-    task = Task(sender.redis_client, 'task.0', container='RAW', serializer='', payload='Primer')
+    task = Task(
+        sender.redis_client, "task.0", container="RAW", serializer="", payload="Primer"
+    )
     sender.put(ep, task)
     for i in range(count):
-        task = Task(sender.redis_client, f'task.{i}', container='RAW', serializer='',
-                    payload=f'task body for task.{i}')
+        task = Task(
+            sender.redis_client,
+            f"task.{i}",
+            container="RAW",
+            serializer="",
+            payload=f"task body for task.{i}",
+        )
         sender.put(ep, task)
         time.sleep(delay)
 
-    task = Task(sender.redis_client, 'sentinel', container='RAW', serializer='',
-                payload='sentinel')
+    task = Task(
+        sender.redis_client,
+        "sentinel",
+        container="RAW",
+        serializer="",
+        payload="sentinel",
+    )
     sender.put(ep, task)
 
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--client", action='store_true',
-                        help="Run in client mode")
-    parser.add_argument("-e", "--endpoint_id", default='testing_ep1',
-                        help="Run in client mode")
+    parser.add_argument(
+        "-c", "--client", action="store_true", help="Run in client mode"
+    )
+    parser.add_argument(
+        "-e", "--endpoint_id", default="testing_ep1", help="Run in client mode"
+    )
 
     args = parser.parse_args()
 

--- a/funcx_forwarder/__init__.py
+++ b/funcx_forwarder/__init__.py
@@ -2,14 +2,16 @@
 
 """
 import logging
-from .version import VERSION
+
 from pythonjsonlogger import jsonlogger
+
+from .version import VERSION
 
 __author__ = "The funcX team"
 __version__ = VERSION
 
 
-def set_stream_logger(name='funcx_forwarder', level=logging.DEBUG, format_string=None):
+def set_stream_logger(name="funcx_forwarder", level=logging.DEBUG, format_string=None):
     """Add a stream log handler.
 
     Args:
@@ -33,4 +35,4 @@ def set_stream_logger(name='funcx_forwarder', level=logging.DEBUG, format_string
     return logger
 
 
-logging.getLogger('funcx_forwarder').addHandler(logging.NullHandler())
+logging.getLogger("funcx_forwarder").addHandler(logging.NullHandler())

--- a/funcx_forwarder/endpoint_db.py
+++ b/funcx_forwarder/endpoint_db.py
@@ -62,7 +62,7 @@ class EndpointDB:
         json_data : {str: str}
         Endpoint metadata as json
         """
-        self.redis_client.hmset("endpoint:{}".format(endpoint_id), json_data)
+        self.redis_client.hmset(f"endpoint:{endpoint_id}", json_data)
 
     def put(self, endpoint_id, payload):
         """Put's the key:payload into a dict and pushes the key onto a queue

--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -1,36 +1,43 @@
 import logging
 import os
-import sys
 import pickle
 import queue
+import sys
 import threading
 import time
-from multiprocessing import Process, Event
 import typing as t
+from multiprocessing import Event, Process
 
 import pika
 import redis
 import requests
 import zmq
-from funcx_common.tasks import TaskState
 from funcx_common.redis import FuncxRedisPubSub, default_redis_connection_factory
 from funcx_common.task_storage import RedisS3Storage
-from funcx_endpoint.executors.high_throughput.messages import Task, Heartbeat, EPStatusReport, ResultsAck
+from funcx_endpoint.executors.high_throughput.messages import (
+    EPStatusReport,
+    Heartbeat,
+    ResultsAck,
+    Task,
+)
 
 import funcx_forwarder
-from funcx_forwarder.taskqueue import TaskQueue
 from funcx_forwarder.endpoint_db import EndpointDB
-from .tasks import RedisTask, InternalTaskState, status_code_convert
+from funcx_forwarder.taskqueue import TaskQueue
+
+from .tasks import InternalTaskState, RedisTask, status_code_convert
 
 logger = logging.getLogger(__name__)
 
 
-loglevels = {50: 'CRITICAL',
-             40: 'ERROR',
-             30: 'WARNING',
-             20: 'INFO',
-             10: 'DEBUG',
-             0: 'NOTSET'}
+loglevels = {
+    50: "CRITICAL",
+    40: "ERROR",
+    30: "WARNING",
+    20: "INFO",
+    10: "DEBUG",
+    0: "NOTSET",
+}
 
 
 class Forwarder(Process):
@@ -85,22 +92,24 @@ class Forwarder(Process):
         connection and automatically reconnects
     """
 
-    def __init__(self,
-                 command_queue,
-                 response_queue,
-                 address: str,
-                 redis_address: str,
-                 rabbitmq_conn_params,
-                 s3_bucket_name: str = os.environ['FUNCX_S3_BUCKET_NAME'],
-                 redis_storage_threshold: int = int(os.environ.get(
-                     'FUNCX_REDIS_STORAGE_THRESHOLD',
-                     20000)),
-                 endpoint_ports=(55001, 55002, 55003),
-                 redis_port: int = 6379,
-                 logging_level=logging.INFO,
-                 heartbeat_period=30,
-                 result_ttl: int = 3600,
-                 keys_dir=os.path.abspath('.curve')):
+    def __init__(
+        self,
+        command_queue,
+        response_queue,
+        address: str,
+        redis_address: str,
+        rabbitmq_conn_params,
+        s3_bucket_name: str = os.environ["FUNCX_S3_BUCKET_NAME"],
+        redis_storage_threshold: int = int(
+            os.environ.get("FUNCX_REDIS_STORAGE_THRESHOLD", 20000)
+        ),
+        endpoint_ports=(55001, 55002, 55003),
+        redis_port: int = 6379,
+        logging_level=logging.INFO,
+        heartbeat_period=30,
+        result_ttl: int = 3600,
+        keys_dir=os.path.abspath(".curve"),
+    ):
         """
         Parameters
         ----------
@@ -151,16 +160,22 @@ class Forwarder(Process):
         self.result_ttl = result_ttl
         # TODO: drop support for imperatively configuring the redis host information
         # for the forwarder. Instead, FUNCX_COMMON_REDIS_URL should be used
-        redis_client = default_redis_connection_factory(f"redis://{redis_address}:{redis_port}")
+        redis_client = default_redis_connection_factory(
+            f"redis://{redis_address}:{redis_port}"
+        )
         self.redis_pubsub = FuncxRedisPubSub(redis_client=redis_client)
         self.endpoint_db = EndpointDB(redis_client=redis_client)
         if not s3_bucket_name:
-            raise Exception("S3 Storage bucket is required. Please specify by setting env variable `S3_BUCKET_NAME`")
-        self.task_storage = RedisS3Storage(s3_bucket_name, redis_threshold=redis_storage_threshold)
+            raise Exception(
+                "S3 Storage bucket is required. Please specify by setting env variable `S3_BUCKET_NAME`"
+            )
+        self.task_storage = RedisS3Storage(
+            s3_bucket_name, redis_threshold=redis_storage_threshold
+        )
         logger.info(f"Initializing forwarder v{funcx_forwarder.__version__}")
         logger.info(f"Forwarder running on public address: {self.address}")
         logger.info(f"REDIS url: {self.redis_url}")
-        logger.info("Log level set to {}".format(loglevels[logging_level]))
+        logger.info(f"Log level set to {loglevels[logging_level]}")
 
         if not os.path.exists(self.keys_dir) or not os.listdir(self.keys_dir):
             logger.info(f"Keys dir empty: {self.keys_dir}, creating keys")
@@ -168,13 +183,15 @@ class Forwarder(Process):
             forwarder_keyfile, _ = zmq.auth.create_certificates(self.keys_dir, "server")
         else:
             logger.info(f"Keys in {self.keys_dir}: {os.listdir(self.keys_dir)}")
-            forwarder_keyfile = os.path.join(self.keys_dir, 'server.key')
+            forwarder_keyfile = os.path.join(self.keys_dir, "server.key")
 
         try:
-            with open(forwarder_keyfile, 'r') as f:
+            with open(forwarder_keyfile) as f:
                 self.forwarder_pubkey = f.read()
         except Exception:
-            logger.exception(f"[CRITICAL] Failed to read server keyfile from {forwarder_keyfile}")
+            logger.exception(
+                f"[CRITICAL] Failed to read server keyfile from {forwarder_keyfile}"
+            )
             raise
 
     @property
@@ -187,7 +204,7 @@ class Forwarder(Process):
         return self.redis_pubsub.redis_client
 
     def command_processor(self, kill_event):
-        """ command_processor listens on the self.command_queue
+        """command_processor listens on the self.command_queue
         for commands and responds with results on the self.response_queue
 
         COMMAND messages are dicts of the form:
@@ -201,48 +218,52 @@ class Forwarder(Process):
             while not kill_event.is_set():
                 command = self.command_queue.get()
                 logger.debug(f"[COMMAND] Received command {command}")
-                if command['command'] == 'LIVENESS':
-                    response = {'response': True,
-                                'id': command.get('id')}
-                elif command['command'] == 'TERMINATE':
+                if command["command"] == "LIVENESS":
+                    response = {"response": True, "id": command.get("id")}
+                elif command["command"] == "TERMINATE":
                     logger.info("[COMMAND] Received TERMINATE command")
-                    response = {'response': True,
-                                'id': command.get('id')}
+                    response = {"response": True, "id": command.get("id")}
                     kill_event.set()
-                elif command['command'] == 'REGISTER_ENDPOINT':
+                elif command["command"] == "REGISTER_ENDPOINT":
                     logger.info("[COMMAND] Received REGISTER_ENDPOINT command")
-                    result = self.register_endpoint(command['endpoint_id'],
-                                                    command['endpoint_address'],
-                                                    command['client_public_key'])
+                    result = self.register_endpoint(
+                        command["endpoint_id"],
+                        command["endpoint_address"],
+                        command["client_public_key"],
+                    )
 
-                    response = {'response': result,
-                                'id': command.get('id'),
-                                'endpoint_id': command['endpoint_id'],
-                                'forwarder_pubkey': self.forwarder_pubkey,
-                                'public_ip': self.address,
-                                'tasks_port': self.tasks_port,
-                                'results_port': self.results_port,
-                                'commands_port': self.commands_port}
+                    response = {
+                        "response": result,
+                        "id": command.get("id"),
+                        "endpoint_id": command["endpoint_id"],
+                        "forwarder_pubkey": self.forwarder_pubkey,
+                        "public_ip": self.address,
+                        "tasks_port": self.tasks_port,
+                        "results_port": self.results_port,
+                        "commands_port": self.commands_port,
+                    }
 
                 else:
-                    response = {'response': False,
-                                'id': command.get('id'),
-                                'reason': 'Unknown command'}
+                    response = {
+                        "response": False,
+                        "id": command.get("id"),
+                        "reason": "Unknown command",
+                    }
 
                 self.response_queue.put(response)
         except Exception:
-            logger.exception('Caught exception while processing command')
+            logger.exception("Caught exception while processing command")
             sys.exit(-1)
 
     def register_endpoint(self, endpoint_id, endpoint_address, key):
-        """ Add new client keys to the zmq authenticator
+        """Add new client keys to the zmq authenticator
 
         Registering an existing endpoint_id is allowed
         """
-        logger.info("endpoint_registered", extra={
-            "log_type": "endpoint_registered",
-            "endpoint_id": endpoint_id
-        })
+        logger.info(
+            "endpoint_registered",
+            extra={"log_type": "endpoint_registered", "endpoint_id": endpoint_id},
+        )
 
         self.update_endpoint_metadata(endpoint_id, endpoint_address)
 
@@ -252,10 +273,9 @@ class Forwarder(Process):
         return True
 
     def update_endpoint_metadata(self, endpoint_id, endpoint_address):
-        """ Geo locate the endpoint and push as metadata into redis
-        """
+        """Geo locate the endpoint and push as metadata into redis"""
         try:
-            resp = requests.get('http://ipinfo.io/{}/json'.format(endpoint_address))
+            resp = requests.get(f"http://ipinfo.io/{endpoint_address}/json")
             self.endpoint_db.set_endpoint_metadata(endpoint_id, resp.json())
         except Exception:
             logger.error(f"Failed to geo locate {endpoint_address}")
@@ -263,26 +283,26 @@ class Forwarder(Process):
             logger.info(f"Endpoint with {endpoint_address} is at {resp}")
 
     def initialize_endpoint_queues(self):
-        ''' Initialize the three queues over which the forwarder communicates with endpoints
+        """Initialize the three queues over which the forwarder communicates with endpoints
         TaskQueue in mode='server' binds to all interfaces by default
-        '''
-        self.tasks_q = TaskQueue('127.0.0.1',
-                                 port=self.tasks_port,
-                                 RCVTIMEO=1,
-                                 keys_dir=self.keys_dir,
-                                 mode='server')
-        self.results_q = TaskQueue('127.0.0.1',
-                                   port=self.results_port,
-                                   keys_dir=self.keys_dir,
-                                   mode='server')
-        self.commands_q = TaskQueue('127.0.0.1',
-                                    port=self.commands_port,
-                                    keys_dir=self.keys_dir,
-                                    mode='server')
+        """
+        self.tasks_q = TaskQueue(
+            "127.0.0.1",
+            port=self.tasks_port,
+            RCVTIMEO=1,
+            keys_dir=self.keys_dir,
+            mode="server",
+        )
+        self.results_q = TaskQueue(
+            "127.0.0.1", port=self.results_port, keys_dir=self.keys_dir, mode="server"
+        )
+        self.commands_q = TaskQueue(
+            "127.0.0.1", port=self.commands_port, keys_dir=self.keys_dir, mode="server"
+        )
         return
 
     def disconnect_endpoint(self, endpoint_id):
-        """ Unsubscribes from Redis pubsub and "removes" endpoint from the tasks channel.
+        """Unsubscribes from Redis pubsub and "removes" endpoint from the tasks channel.
         This method does nothing if the endpoint is already disconnected.
 
         Triggered by zmq messages not getting delivered (heartbeats, tasks, result acks)
@@ -294,16 +314,15 @@ class Forwarder(Process):
         if not disconnected_endpoint:
             return
 
-        logger.info("endpoint_disconnected", extra={
-            "log_type": "endpoint_disconnected",
-            "endpoint_id": endpoint_id
-        })
+        logger.info(
+            "endpoint_disconnected",
+            extra={"log_type": "endpoint_disconnected", "endpoint_id": endpoint_id},
+        )
 
         self.redis_pubsub.unsubscribe(endpoint_id)
 
     def add_endpoint_keys(self, ep_id, ep_key):
-        """ To remove. this is not used.
-        """
+        """To remove. this is not used."""
         self.tasks_q.add_client_key(ep_key)
         self.results_q.add_client_key(ep_key)
         self.commands_q.add_client_key(ep_key)
@@ -312,57 +331,67 @@ class Forwarder(Process):
         self.redis_pubsub.subscribe(ep_id)
 
     def heartbeat(self):
-        """ ZMQ contexts are not thread-safe, heartbeats should happen on the same thread.
-        """
+        """ZMQ contexts are not thread-safe, heartbeats should happen on the same thread."""
         if self._last_heartbeat + self.heartbeat_period > time.time():
             return
         logger.info("Heartbeat")
         dest_endpoint_list = list(self.connected_endpoints.keys())
         for dest_endpoint in dest_endpoint_list:
-            logger.debug(f"Sending heartbeat to {dest_endpoint}", extra={
-                "log_type": "endpoint_heartbeat_sent",
-                "endpoint_id": dest_endpoint
-            })
+            logger.debug(
+                f"Sending heartbeat to {dest_endpoint}",
+                extra={
+                    "log_type": "endpoint_heartbeat_sent",
+                    "endpoint_id": dest_endpoint,
+                },
+            )
             msg = Heartbeat(endpoint_id=dest_endpoint)
             try:
-                self.tasks_q.put(dest_endpoint.encode('utf-8'),
-                                 msg.pack())
-                self.connected_endpoints[dest_endpoint]['missed_heartbeats'] = 0
+                self.tasks_q.put(dest_endpoint.encode("utf-8"), msg.pack())
+                self.connected_endpoints[dest_endpoint]["missed_heartbeats"] = 0
 
             except (zmq.error.ZMQError, zmq.Again):
-                logger.exception(f"Endpoint:{dest_endpoint} is unreachable over heartbeats")
+                logger.exception(
+                    f"Endpoint:{dest_endpoint} is unreachable over heartbeats"
+                )
                 self.disconnect_endpoint(dest_endpoint)
         self._last_heartbeat = time.time()
 
     def handle_endpoint_connection(self):
-        ''' Receive endpoint connection messages. Only connection messages
+        """Receive endpoint connection messages. Only connection messages
         are sent from the interchange -> forwarder on the task_q
-        '''
+        """
         try:
-            b_ep_id, b_reg_message = self.tasks_q.get(timeout=0)  # timeout in ms # Update to 0ms
+            b_ep_id, b_reg_message = self.tasks_q.get(
+                timeout=0
+            )  # timeout in ms # Update to 0ms
             # At this point ep_id is authenticated by means having the client keys.
-            ep_id = b_ep_id.decode('utf-8')
+            ep_id = b_ep_id.decode("utf-8")
             reg_message = pickle.loads(b_reg_message)
 
             if ep_id in self.connected_endpoints:
                 # this is normal, it just means that the endpoint never reached Disconnected
                 # state before connecting again
-                logger.info(f"[MAIN] Endpoint:{ep_id} attempted connect when it already is in connected list", extra={
-                    "log_type": "endpoint_reconnected",
-                    "endpoint_id": ep_id
-                })
+                logger.info(
+                    f"[MAIN] Endpoint:{ep_id} attempted connect when it already is in connected list",
+                    extra={"log_type": "endpoint_reconnected", "endpoint_id": ep_id},
+                )
             else:
-                logger.info("endpoint_connected", extra={
-                    "log_type": "endpoint_connected",
-                    "endpoint_id": ep_id,
-                    "registration_message": reg_message
-                })
+                logger.info(
+                    "endpoint_connected",
+                    extra={
+                        "log_type": "endpoint_connected",
+                        "endpoint_id": ep_id,
+                        "registration_message": reg_message,
+                    },
+                )
                 # Now subscribe to messages for ep_id
                 # if this endpoint is already in self.connected_endpoints, it is already subscribed
                 self.add_subscriber(ep_id)
 
-            self.connected_endpoints[ep_id] = {'registration_message': reg_message,
-                                               'missed_heartbeats': 0}
+            self.connected_endpoints[ep_id] = {
+                "registration_message": reg_message,
+                "missed_heartbeats": 0,
+            }
         except zmq.Again:
             pass
         except Exception:
@@ -376,25 +405,28 @@ class Forwarder(Process):
             "function_id": task.function_id,
             "endpoint_id": task.endpoint,
             "container_id": task.container,
-            "log_type": "task_transition"
+            "log_type": "task_transition",
         }
         logger.info(transition_name, extra=extra_logging)
 
     def forward_task_to_endpoint(self):
-        ''' Migrates one task from redis to the appropriate endpoint
+        """Migrates one task from redis to the appropriate endpoint
 
         Returns:
             int: Count of tasks migrated (0,1)
-        '''
+        """
         # Now wait for any messages on REDIS that needs forwarding.
         task = None
         try:
             dest_endpoint, task_id = self.redis_pubsub.get(timeout=0)
             task = RedisTask(self.redis_client, task_id)
-            logger.debug(f"Got message from REDIS: {dest_endpoint}:{task}", extra={
-                "log_type": "forwarder_redis_task_get",
-                "endpoint_id": dest_endpoint
-            })
+            logger.debug(
+                f"Got message from REDIS: {dest_endpoint}:{task}",
+                extra={
+                    "log_type": "forwarder_redis_task_get",
+                    "endpoint_id": dest_endpoint,
+                },
+            )
         except queue.Empty:
             return 0
         except Exception:
@@ -404,48 +436,53 @@ class Forwarder(Process):
         if dest_endpoint not in self.connected_endpoints:
             # At this point we should be unsubscribed and receiving only messages
             # from the TCP buffers.
-            logger.warning(f"Putting back REDIS message for unconnected endpoint: {dest_endpoint}:{task}", extra={
-                "log_type": "forwarder_redis_task_put",
-                "endpoint_id": dest_endpoint
-            })
+            logger.warning(
+                f"Putting back REDIS message for unconnected endpoint: {dest_endpoint}:{task}",
+                extra={
+                    "log_type": "forwarder_redis_task_put",
+                    "endpoint_id": dest_endpoint,
+                },
+            )
             self.redis_pubsub.put(dest_endpoint, task)
             self.redis_pubsub.unsubscribe(dest_endpoint)
         else:
             try:
                 task_id = task.task_id
                 logger.info(f"Sending task:{task_id} to endpoint:{dest_endpoint}")
-                zmq_task = Task(task_id,
-                                task.container,
-                                task.payload)
+                zmq_task = Task(task_id, task.container, task.payload)
             except TypeError:
                 # A TypeError is raised when the Task object can't be recomposed from REDIS
                 # due to missing values during high-workload events.
                 logger.exception(f"Unable to access task {task_id} from redis")
-                logger.debug(f"Task:{task_id} is now LOST", extra={
-                    "log_type": "task_lost",
-                    "endpoint_id": dest_endpoint,
-                    "task_id": task_id
-                })
+                logger.debug(
+                    f"Task:{task_id} is now LOST",
+                    extra={
+                        "log_type": "task_lost",
+                        "endpoint_id": dest_endpoint,
+                        "task_id": task_id,
+                    },
+                )
                 return 0
 
             try:
-                self.tasks_q.put(dest_endpoint.encode('utf-8'),
-                                 zmq_task.pack())
+                self.tasks_q.put(dest_endpoint.encode("utf-8"), zmq_task.pack())
             except (zmq.error.ZMQError, zmq.Again):
                 logger.exception(f"Endpoint:{dest_endpoint} is unreachable")
                 # put task back in redis since it was not sent to endpoint
                 self.redis_pubsub.put(dest_endpoint, task)
                 self.disconnect_endpoint(dest_endpoint)
             except Exception:
-                logger.exception(f"Caught error while sending {task_id} to {dest_endpoint}")
+                logger.exception(
+                    f"Caught error while sending {task_id} to {dest_endpoint}"
+                )
                 # put task back in redis since it was not sent to endpoint
                 self.redis_pubsub.put(dest_endpoint, task)
             else:
-                self.log_task_transition(task, 'dispatched_to_endpoint')
+                self.log_task_transition(task, "dispatched_to_endpoint")
         return 1
 
     def handle_results(self):
-        ''' Receive incoming results on results_q and update Redis with results
+        """Receive incoming results on results_q and update Redis with results
 
         NOTE: Results can arrive on this queue when the endpoint is in any of the 3 states
         (Registered, Connected, Disconnected), and we will accept the results. This is because
@@ -465,35 +502,45 @@ class Forwarder(Process):
             but a zmq send failed over a different pipe, sending the endpoint do Disconnected
             state. The results pipe could still be working, or it could've started working
             again before the connection message is sent again
-        '''
+        """
         try:
             # timeout in ms, when 0 it's nonblocking
             b_ep_id, b_message = self.results_q.get(block=False, timeout=0)
-            endpoint_id = b_ep_id.decode('utf-8')
+            endpoint_id = b_ep_id.decode("utf-8")
 
-            if b_message == b'HEARTBEAT':
-                logger.debug(f"Received heartbeat from {endpoint_id} over results channel", extra={
-                    "log_type": "endpoint_heartbeat_received",
-                    "endpoint_id": endpoint_id
-                })
+            if b_message == b"HEARTBEAT":
+                logger.debug(
+                    f"Received heartbeat from {endpoint_id} over results channel",
+                    extra={
+                        "log_type": "endpoint_heartbeat_received",
+                        "endpoint_id": endpoint_id,
+                    },
+                )
                 return
 
             try:
                 message = pickle.loads(b_message)
             except Exception:
-                logger.exception(f"Failed to unpickle message from results_q, message:{b_message}")
+                logger.exception(
+                    f"Failed to unpickle message from results_q, message:{b_message}"
+                )
 
             if isinstance(message, EPStatusReport):
-                logger.debug("endpoint_status_message", extra={
-                    "log_type": "endpoint_status_message",
-                    "endpoint_id": endpoint_id,
-                    "endpoint_status_message": message.__dict__
-                })
+                logger.debug(
+                    "endpoint_status_message",
+                    extra={
+                        "log_type": "endpoint_status_message",
+                        "endpoint_id": endpoint_id,
+                        "endpoint_status_message": message.__dict__,
+                    },
+                )
                 # Update endpoint status
                 try:
                     self.endpoint_db.put(endpoint_id, message.ep_status)
                 except Exception:
-                    logger.error("Caught error while trying to push endpoint status data into redis")
+                    logger.error(
+                        "Caught error while trying to push endpoint status data into redis"
+                    )
 
                 # Update task status from endpoint
                 task_status_delta = message.task_statuses
@@ -505,23 +552,28 @@ class Forwarder(Process):
                     task.status = status
                 return
 
-            if 'registration' in message:
+            if "registration" in message:
                 logger.debug(f"Registration message from {message['registration']}")
                 return
 
             # only messages with a result or an exception are processed past this point
-            result_or_exception = 'result' in message or 'exception' in message
+            result_or_exception = "result" in message or "exception" in message
             if not result_or_exception:
-                logger.warning("A task result message was received without a result or an exception", extra={
-                    "endpoint_id": endpoint_id,
-                    "endpoint_status_message": message.__dict__
-                })
+                logger.warning(
+                    "A task result message was received without a result or an exception",
+                    extra={
+                        "endpoint_id": endpoint_id,
+                        "endpoint_status_message": message.__dict__,
+                    },
+                )
                 return
 
-            task_id = message['task_id']
+            task_id = message["task_id"]
 
             if not RedisTask.exists(self.redis_client, task_id):
-                logger.warning(f"Got result for task that does not exist in redis: {task_id}")
+                logger.warning(
+                    f"Got result for task that does not exist in redis: {task_id}"
+                )
                 # if the task does not exist in redis, it may mean it was retrieved by
                 # the user and deleted from redis before it could be acked so the
                 # endpoint sent another result message. This means we should ack this
@@ -545,18 +597,20 @@ class Forwarder(Process):
                 # A ValueError is raised if the task was wiped from REDIS by a client-fetch
                 # We should ack the endpoint so that it can wipe it's local cache
                 self.handle_results_ack(endpoint_id, task_id)
-                logger.warning(f"ACK requested for task:{task_id} which was already fetched by client.")
+                logger.warning(
+                    f"ACK requested for task:{task_id} which was already fetched by client."
+                )
                 return
 
             # this critical section is where the final task redis data is set,
             # and the task result will not be acked if this fails
-            if 'result' in message:
+            if "result" in message:
                 task.status = TaskState.SUCCESS
-                self.task_storage.store_result(task, message['result'])
+                self.task_storage.store_result(task, message["result"])
                 task.completion_time = time.time()
-            elif 'exception' in message:
+            elif "exception" in message:
                 task.status = TaskState.FAILED
-                task.exception = message['exception']
+                task.exception = message["exception"]
                 task.completion_time = time.time()
             task.set_expire(self.result_ttl)
 
@@ -566,18 +620,22 @@ class Forwarder(Process):
             if task_group_id:
                 connection = pika.BlockingConnection(self.rabbitmq_conn_params)
                 channel = connection.channel()
-                channel.exchange_declare(exchange='tasks', exchange_type='direct')
+                channel.exchange_declare(exchange="tasks", exchange_type="direct")
                 channel.queue_declare(queue=task_group_id)
-                channel.queue_bind(task_group_id, 'tasks')
+                channel.queue_bind(task_group_id, "tasks")
 
                 # important: the FuncX client must be capable of receiving the same
                 # task_id multiple times, in case this bit succeeds but code below this
                 # fails and this must be retried
-                channel.basic_publish(exchange='tasks', routing_key=task_group_id, body=task_id)
-                logger.debug(f"Publishing to RabbitMQ routing key {task_group_id} : {task_id}")
+                channel.basic_publish(
+                    exchange="tasks", routing_key=task_group_id, body=task_id
+                )
+                logger.debug(
+                    f"Publishing to RabbitMQ routing key {task_group_id} : {task_id}"
+                )
                 connection.close()
 
-                self.log_task_transition(task, 'result_enqueued')
+                self.log_task_transition(task, "result_enqueued")
 
             # internally, the task is only considered complete when both critical
             # sections above have succeeded (redis data is sent and the task_id is
@@ -592,49 +650,59 @@ class Forwarder(Process):
 
     def handle_results_ack(self, endpoint_id, task_id):
         if endpoint_id not in self.connected_endpoints:
-            logger.warning(f"Attempting to send results Ack to disconnected endpoint: {endpoint_id}", extra={
-                "log_type": "disconnected_ack_attempt",
-                "endpoint_id": endpoint_id,
-                "task_id": task_id
-            })
+            logger.warning(
+                f"Attempting to send results Ack to disconnected endpoint: {endpoint_id}",
+                extra={
+                    "log_type": "disconnected_ack_attempt",
+                    "endpoint_id": endpoint_id,
+                    "task_id": task_id,
+                },
+            )
 
         # TODO: remove once endpoint version 0.3.* is deprecated
-        reg_message = self.connected_endpoints[endpoint_id]['registration_message']
+        reg_message = self.connected_endpoints[endpoint_id]["registration_message"]
         # if the key funcx_endpoint_version is in the registration message, it means
         # the endpoint version is >=0.3.3, because 0.3.3 is the first endpoint version
         # where we started sending the funcx_endpoint_version key to the forwarder
         if "funcx_endpoint_version" not in reg_message:
-            logger.debug(f"Ack not sent to endpoint {endpoint_id} for backwards compatability because it has version <0.3.3")
+            logger.debug(
+                f"Ack not sent to endpoint {endpoint_id} for backwards compatability because it has version <0.3.3"
+            )
             return
 
         msg = ResultsAck(task_id=task_id)
-        logger.debug(f"Sending Result Ack to endpoint {endpoint_id} for task {task_id}: {msg}", extra={
-            "log_type": "results_ack",
-            "endpoint_id": endpoint_id,
-            "task_id": task_id
-        })
+        logger.debug(
+            f"Sending Result Ack to endpoint {endpoint_id} for task {task_id}: {msg}",
+            extra={
+                "log_type": "results_ack",
+                "endpoint_id": endpoint_id,
+                "task_id": task_id,
+            },
+        )
         try:
             # send an ack
-            self.tasks_q.put(endpoint_id.encode('utf-8'),
-                             msg.pack())
+            self.tasks_q.put(endpoint_id.encode("utf-8"), msg.pack())
         except (zmq.error.ZMQError, zmq.Again):
             logger.exception(f"Endpoint:{endpoint_id} results ack send failed")
             self.disconnect_endpoint(endpoint_id)
 
     def run(self):
-        """ Process entry point
-        """
+        """Process entry point"""
         try:
             logger.info("[MAIN] Loop starting")
             logger.info("[MAIN] Connecting to redis")
             logger.info(f"[MAIN] Forwarder listening for tasks on: {self.tasks_port}")
-            logger.info(f"[MAIN] Forwarder listening for results on: {self.results_port}")
+            logger.info(
+                f"[MAIN] Forwarder listening for results on: {self.results_port}"
+            )
             logger.info(f"[MAIN] Forwarder issuing commands on: {self.commands_port}")
 
             self.initialize_endpoint_queues()
-            self._command_processor_thread = threading.Thread(target=self.command_processor,
-                                                              args=(self.kill_event,),
-                                                              name="forwarder-command-processor")
+            self._command_processor_thread = threading.Thread(
+                target=self.command_processor,
+                args=(self.kill_event,),
+                name="forwarder-command-processor",
+            )
             self._command_processor_thread.start()
 
             while True:
@@ -652,5 +720,5 @@ class Forwarder(Process):
                 self.forward_task_to_endpoint()
                 self.handle_results()
         except Exception:
-            logger.exception('Caught exception while running forwarder')
+            logger.exception("Caught exception while running forwarder")
             sys.exit(-1)

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -6,60 +6,56 @@ creates an appropriate forwarder to which the endpoint can connect up.
 import argparse
 import json
 import logging
+import sys
+import time
+from multiprocessing import Queue
+
 import pika
 import redis
-import time
-import sys
+from flask import Flask, jsonify, request
 
-from flask import Flask, jsonify
-from flask import request
-
-from funcx_forwarder.version import VERSION, MIN_EP_VERSION
 # from funcx_forwarder.forwarderobject import spawn_forwarder
 from funcx_forwarder import set_stream_logger
 from funcx_forwarder.forwarder import Forwarder
-from multiprocessing import Queue
+from funcx_forwarder.version import MIN_EP_VERSION, VERSION
 
 app = Flask(__name__)
 logger = logging.getLogger(__name__)
 
 
-@app.route('/ping')
+@app.route("/ping")
 def ping():
-    """ Minimal liveness response
-    """
+    """Minimal liveness response"""
     return "pong"
 
 
-@app.route('/version')
+@app.route("/version")
 def version():
-    return jsonify({
-        "forwarder": VERSION,
-        "min_ep_version": MIN_EP_VERSION
-    })
+    return jsonify({"forwarder": VERSION, "min_ep_version": MIN_EP_VERSION})
 
 
-@app.route('/map.json', methods=['GET'])
+@app.route("/map.json", methods=["GET"])
 def get_map_json():
-    """ Paint a map of utilization
-    """
+    """Paint a map of utilization"""
     results = []
-    redis_client = app.config['redis_client']
-    for key in redis_client.keys('ep_status_*'):
+    redis_client = app.config["redis_client"]
+    for key in redis_client.keys("ep_status_*"):
         try:
-            logger.debug("Getting key {}".format(key))
+            logger.debug(f"Getting key {key}")
             items = redis_client.lrange(key, 0, 0)
             if items:
                 last = json.loads(items[0])
             else:
                 continue
-            ep_id = key.split('_')[2]
-            ep_meta = redis_client.hgetall('endpoint:{}'.format(ep_id))
-            lat, lon = ep_meta['loc'].split(',')
-            current = {'org': ep_meta['org'].replace(',', '. '),
-                       'core_hrs': last['total_core_hrs'],
-                       'lat': lat,
-                       'long': lon}
+            ep_id = key.split("_")[2]
+            ep_meta = redis_client.hgetall(f"endpoint:{ep_id}")
+            lat, lon = ep_meta["loc"].split(",")
+            current = {
+                "org": ep_meta["org"].replace(",", ". "),
+                "core_hrs": last["total_core_hrs"],
+                "lat": lat,
+                "long": lon,
+            }
             results.append(current)
 
         except Exception:
@@ -69,23 +65,24 @@ def get_map_json():
     return dict(data=results)
 
 
-@app.route('/map.csv', methods=['GET'])
+@app.route("/map.csv", methods=["GET"])
 def get_map():
-    """ Paint a map of utilization
-    """
-    redis_client = app.config['redis_client']
+    """Paint a map of utilization"""
+    redis_client = app.config["redis_client"]
     csv_string = "org,core_hrs,lat,long\n</br>"
-    for key in redis_client.keys('ep_status_*'):
+    for key in redis_client.keys("ep_status_*"):
         try:
-            logger.debug("Getting key {}".format(key))
+            logger.debug(f"Getting key {key}")
             items = redis_client.lrange(key, 0, 0)
             if items:
                 last = json.loads(items[0])
             else:
                 continue
-            ep_id = key.split('_')[2]
-            ep_meta = redis_client.hgetall('endpoint:{}'.format(ep_id))
-            current = "{},{},{}\n</br>".format(ep_meta['org'].replace(',', '.'), last['total_core_hrs'], ep_meta['loc'])
+            ep_id = key.split("_")[2]
+            ep_meta = redis_client.hgetall(f"endpoint:{ep_id}")
+            current = "{},{},{}\n</br>".format(
+                ep_meta["org"].replace(",", "."), last["total_core_hrs"], ep_meta["loc"]
+            )
             csv_string += current
 
         except Exception:
@@ -98,92 +95,112 @@ def wait_for_forwarder(fw):
     fw.join()
 
 
-@app.route('/test/<method>', methods=['GET'])
+@app.route("/test/<method>", methods=["GET"])
 def test(method):
     logger.debug(f"In test with {method}")
-    logger.debug(app.config['forwarder_command'])
+    logger.debug(app.config["forwarder_command"])
 
     command_id = int(time.time())
-    if method == 'TERMINATE':
-        command = {'command': 'REGISTER_ENDPOINT',
-                   'endpoint_id': 'Foooo',
-                   'id': command_id}
+    if method == "TERMINATE":
+        command = {
+            "command": "REGISTER_ENDPOINT",
+            "endpoint_id": "Foooo",
+            "id": command_id,
+        }
 
-    elif method == 'REGISTER_ENDPOINT':
-        command = {'command': 'REGISTER_ENDPOINT',
-                   'client_keys': 'CLIENT_KEYS',
-                   'endpoint_id': 'Foooo',
-                   'id': command_id}
+    elif method == "REGISTER_ENDPOINT":
+        command = {
+            "command": "REGISTER_ENDPOINT",
+            "client_keys": "CLIENT_KEYS",
+            "endpoint_id": "Foooo",
+            "id": command_id,
+        }
     else:
         logger.debug("Unknown method")
-        return 'None'
+        return "None"
 
-    app.config['forwarder_command'].put(command)
-    response = app.config['forwarder_response'].get()
+    app.config["forwarder_command"].put(command)
+    response = app.config["forwarder_response"].get()
 
     return response
     # return "Hello"
 
 
-@app.route('/register', methods=['POST'])
+@app.route("/register", methods=["POST"])
 def register():
-    """ Register an endpoint request
+    """Register an endpoint request
 
     1. Register client key with the forwarder instance
     2. Pass connection info back as a json response.
     """
     reg_info = request.get_json()
-    endpoint_id = reg_info['endpoint_id']
-    logger.debug(f"Registering endpoint : {endpoint_id}", extra={
-        "log_type": "forwarder_endpoint_registration_start",
-        "endpoint_id": endpoint_id
-    })
-    app.config['forwarder_command'].put({'command': 'REGISTER_ENDPOINT',
-                                         'endpoint_id': reg_info['endpoint_id'],
-                                         'endpoint_address': reg_info['endpoint_addr'],
-                                         'client_public_key': reg_info.get('client_public_key', None),
-                                         'id': 0})
-    ret_package = app.config['forwarder_response'].get()
-    logger.debug("forwarder_endpoint_registration_response", extra={
-        "log_type": "forwarder_endpoint_registration_response",
-        "registration_response": ret_package
-    })
+    endpoint_id = reg_info["endpoint_id"]
+    logger.debug(
+        f"Registering endpoint : {endpoint_id}",
+        extra={
+            "log_type": "forwarder_endpoint_registration_start",
+            "endpoint_id": endpoint_id,
+        },
+    )
+    app.config["forwarder_command"].put(
+        {
+            "command": "REGISTER_ENDPOINT",
+            "endpoint_id": reg_info["endpoint_id"],
+            "endpoint_address": reg_info["endpoint_addr"],
+            "client_public_key": reg_info.get("client_public_key", None),
+            "id": 0,
+        }
+    )
+    ret_package = app.config["forwarder_response"].get()
+    logger.debug(
+        "forwarder_endpoint_registration_response",
+        extra={
+            "log_type": "forwarder_endpoint_registration_response",
+            "registration_response": ret_package,
+        },
+    )
     return ret_package
 
 
-@app.route('/list_mappings')
+@app.route("/list_mappings")
 def list_mappings():
-    return app.config['ep_mapping']
+    return app.config["ep_mapping"]
 
 
 def cli():
     try:
         cli_run()
     except Exception:
-        logger.exception('Caught exception while starting forwarder')
+        logger.exception("Caught exception while starting forwarder")
         sys.exit(-1)
 
 
 def cli_run():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--port", default=8080,
-                        help="Port at which the service will listen on")
-    parser.add_argument("-a", "--address", required=True,
-                        help="Address at which the service is running. This is the address passed to the endpoints")
-    parser.add_argument("-c", "--config", default=None,
-                        help="Config file")
-    parser.add_argument("-r", "--redishost", required=True,
-                        help="Redis host address")
-    parser.add_argument("--redisport", default=6379,
-                        help="Redis port")
-    parser.add_argument("--rabbitmquri", required=True,
-                        help="RabbitMQ connection uri")
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Enables debug logging")
-    parser.add_argument("--result_ttl", default=3600,
-                        help="Set task TTL in REDIS after the result is available.")
-    parser.add_argument("-v", "--version", action='store_true',
-                        help="Print version information")
+    parser.add_argument(
+        "-p", "--port", default=8080, help="Port at which the service will listen on"
+    )
+    parser.add_argument(
+        "-a",
+        "--address",
+        required=True,
+        help="Address at which the service is running. This is the address passed to the endpoints",
+    )
+    parser.add_argument("-c", "--config", default=None, help="Config file")
+    parser.add_argument("-r", "--redishost", required=True, help="Redis host address")
+    parser.add_argument("--redisport", default=6379, help="Redis port")
+    parser.add_argument("--rabbitmquri", required=True, help="RabbitMQ connection uri")
+    parser.add_argument(
+        "-d", "--debug", action="store_true", help="Enables debug logging"
+    )
+    parser.add_argument(
+        "--result_ttl",
+        default=3600,
+        help="Set task TTL in REDIS after the result is available.",
+    )
+    parser.add_argument(
+        "-v", "--version", action="store_true", help="Print version information"
+    )
     parser.add_argument(
         "--endpoint-base-port",
         default=55001,
@@ -205,36 +222,36 @@ def cli_run():
         logger.debug(f"Forwarder version: {VERSION}")
         logger.debug(f"Forwarder minimum endpoint version: {MIN_EP_VERSION}")
 
-    app.config['address'] = args.address
-    app.config['ep_mapping'] = {}
-    app.config['redis_address'] = args.redishost
-    app.config['redis_client'] = redis.StrictRedis(
-        host=args.redishost,
-        port=int(args.redisport),
-        decode_responses=True
+    app.config["address"] = args.address
+    app.config["ep_mapping"] = {}
+    app.config["redis_address"] = args.redishost
+    app.config["redis_client"] = redis.StrictRedis(
+        host=args.redishost, port=int(args.redisport), decode_responses=True
     )
 
     rabbitmq_conn_params = pika.URLParameters(args.rabbitmquri)
-    app.config['rabbitmq_conn_params'] = rabbitmq_conn_params
+    app.config["rabbitmq_conn_params"] = rabbitmq_conn_params
 
-    app.config['forwarder_command'] = Queue()
-    app.config['forwarder_response'] = Queue()
+    app.config["forwarder_command"] = Queue()
+    app.config["forwarder_response"] = Queue()
 
-    fw = Forwarder(app.config['forwarder_command'],
-                   app.config['forwarder_response'],
-                   args.address,
-                   args.redishost,
-                   rabbitmq_conn_params,
-                   endpoint_ports=range(args.endpoint_base_port, args.endpoint_base_port + 3),
-                   logging_level=logging_level,
-                   result_ttl=int(args.result_ttl),
-                   redis_port=args.redisport)
+    fw = Forwarder(
+        app.config["forwarder_command"],
+        app.config["forwarder_response"],
+        args.address,
+        args.redishost,
+        rabbitmq_conn_params,
+        endpoint_ports=range(args.endpoint_base_port, args.endpoint_base_port + 3),
+        logging_level=logging_level,
+        result_ttl=int(args.result_ttl),
+        redis_port=args.redisport,
+    )
     fw.start()
-    app.config['forwarder_process'] = fw
+    app.config["forwarder_process"] = fw
 
     # Run a test command to make sure the forwarder is online
-    app.config['forwarder_command'].put({'command': 'LIVENESS', 'id': 0})
-    response = app.config['forwarder_response'].get()
+    app.config["forwarder_command"].put({"command": "LIVENESS", "id": 0})
+    response = app.config["forwarder_response"].get()
     logger.debug(response)
 
     # DEBUG ---- <WARNING THIS IS ONLY FOR DEBUG>
@@ -262,14 +279,14 @@ def cli_run():
 
     except Exception as e:
         # This doesn't do anything
-        logger.debug("Caught exception : {}".format(e))
+        logger.debug(f"Caught exception : {e}")
         exit(-1)
 
     finally:
         logger.debug("Graceful exit")
-        app.config['forwarder_command'].put({'command': 'TERMINATE'})
+        app.config["forwarder_command"].put({"command": "TERMINATE"})
         fw.terminate()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -184,7 +184,8 @@ def cli_run():
         "-a",
         "--address",
         required=True,
-        help="Address at which the service is running. This is the address passed to the endpoints",
+        help="Address at which the service is running. "
+        "This is the address passed to the endpoints",
     )
     parser.add_argument("-c", "--config", default=None, help="Config file")
     parser.add_argument("-r", "--redishost", required=True, help="Redis host address")
@@ -260,10 +261,14 @@ def cli_run():
     with open('/tmp/client.key') as f:
         client_key = f.read()
     print("Pushing client key : ", client_key)
-    app.config['forwarder_command'].put({'command' : 'REGISTER_ENDPOINT',
-                                         'endpoint_id': 'edb1ebd4-f99a-4f99-b8aa-688da5b5ede7',
-                                         'client_public_key': client_key,
-                                         'id': 0})
+    app.config['forwarder_command'].put(
+        {
+            'command' : 'REGISTER_ENDPOINT',
+            'endpoint_id': 'edb1ebd4-f99a-4f99-b8aa-688da5b5ede7',
+            'client_public_key': client_key,
+            'id': 0
+         }
+    )
     response = app.config['forwarder_response'].get()
     print(f"Registration response : {response}")
     """

--- a/funcx_forwarder/taskqueue.py
+++ b/funcx_forwarder/taskqueue.py
@@ -1,28 +1,30 @@
+import logging
 import os
+import uuid
+
 import zmq
 import zmq.auth
 from zmq.auth.thread import ThreadAuthenticator
-import uuid
-import logging
 
 logger = logging.getLogger(__name__)
 
 
-class TaskQueue(object):
-    """ Outgoing task queue from the executor to the Interchange
-    """
+class TaskQueue:
+    """Outgoing task queue from the executor to the Interchange"""
 
-    def __init__(self,
-                 address: str,
-                 port: int,
-                 identity: str = str(uuid.uuid4()),
-                 zmq_context=None,
-                 set_hwm=False,
-                 RCVTIMEO=None,
-                 SNDTIMEO=None,
-                 ironhouse: bool = False,
-                 keys_dir: str = os.path.abspath('.curve'),
-                 mode: str = 'client'):
+    def __init__(
+        self,
+        address: str,
+        port: int,
+        identity: str = str(uuid.uuid4()),
+        zmq_context=None,
+        set_hwm=False,
+        RCVTIMEO=None,
+        SNDTIMEO=None,
+        ironhouse: bool = False,
+        keys_dir: str = os.path.abspath(".curve"),
+        mode: str = "client",
+    ):
         """
         Parameters
         ----------
@@ -57,18 +59,20 @@ class TaskQueue(object):
         self.ironhouse = ironhouse
         self.keys_dir = keys_dir
 
-        if self.mode == 'server':
+        if self.mode == "server":
             logger.debug("Configuring server")
             self.zmq_socket = self.context.socket(zmq.ROUTER)
             self.zmq_socket.set(zmq.ROUTER_MANDATORY, 1)
             self.zmq_socket.set(zmq.ROUTER_HANDOVER, 1)
             self.setup_server_auth()
-        elif self.mode == 'client':
+        elif self.mode == "client":
             self.zmq_socket = self.context.socket(zmq.DEALER)
             self.setup_client_auth()
-            self.zmq_socket.setsockopt(zmq.IDENTITY, identity.encode('utf-8'))
+            self.zmq_socket.setsockopt(zmq.IDENTITY, identity.encode("utf-8"))
         else:
-            raise ValueError("TaskQueue must be initialized with mode set to 'server' or 'client'")
+            raise ValueError(
+                "TaskQueue must be initialized with mode set to 'server' or 'client'"
+            )
 
         if set_hwm:
             self.zmq_socket.set_hwm(0)
@@ -78,10 +82,10 @@ class TaskQueue(object):
             self.zmq_socket.setsockopt(zmq.SNDTIMEO, SNDTIMEO)
 
         # all zmq setsockopt calls must be done before bind/connect is called
-        if self.mode == 'server':
-            self.zmq_socket.bind("tcp://*:{}".format(port))
-        elif self.mode == 'client':
-            self.zmq_socket.connect("tcp://{}:{}".format(address, port))
+        if self.mode == "server":
+            self.zmq_socket.bind(f"tcp://*:{port}")
+        elif self.mode == "client":
+            self.zmq_socket.connect(f"tcp://{address}:{port}")
 
         self.poller = zmq.Poller()
         self.poller.register(self.zmq_socket, zmq.POLLOUT)
@@ -97,10 +101,10 @@ class TaskQueue(object):
         logger.info("Adding client key")
         if self.ironhouse:
             # Use the ironhouse ZMQ pattern: http://hintjens.com/blog:49#toc6
-            with open(os.path.join(self.keys_dir, f'{endpoint_id}.key'), 'w') as f:
+            with open(os.path.join(self.keys_dir, f"{endpoint_id}.key"), "w") as f:
                 f.write(client_key)
             try:
-                self.auth.configure_curve(domain='*', location=self.keys_dir)
+                self.auth.configure_curve(domain="*", location=self.keys_dir)
             except Exception:
                 logger.exception("Failed to load keys from {self.keys_dir}")
         return
@@ -114,7 +118,7 @@ class TaskQueue(object):
         # Tell the authenticator how to handle CURVE requests
         if not self.ironhouse:
             # Use the stonehouse ZMQ pattern: http://hintjens.com/blog:49#toc5
-            self.auth.configure_curve(domain='*', location=zmq.auth.CURVE_ALLOW_ANY)
+            self.auth.configure_curve(domain="*", location=zmq.auth.CURVE_ALLOW_ANY)
 
         server_secret_file = os.path.join(self.keys_dir, "server.key_secret")
         server_public, server_secret = zmq.auth.load_certificate(server_secret_file)
@@ -163,7 +167,7 @@ class TaskQueue(object):
         return self.zmq_socket.send_multipart([message])
 
     def put(self, dest, message):
-        """ This function needs to be fast at the same time aware of the possibility of
+        """This function needs to be fast at the same time aware of the possibility of
         ZMQ pipes overflowing.
 
         The timeout increases slowly if contention is detected on ZMQ pipes.
@@ -186,7 +190,7 @@ class TaskQueue(object):
         zmq.error.ZMQError: Host unreachable (if client disconnects?)
 
         """
-        if self.mode == 'client':
+        if self.mode == "client":
             return self.zmq_socket.send_multipart([message])
         else:
             return self.zmq_socket.send_multipart([dest, message])

--- a/funcx_forwarder/taskqueue.py
+++ b/funcx_forwarder/taskqueue.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import typing as t
 import uuid
 
 import zmq
@@ -16,13 +17,13 @@ class TaskQueue:
         self,
         address: str,
         port: int,
-        identity: str = str(uuid.uuid4()),
+        identity: t.Optional[str] = None,
         zmq_context=None,
         set_hwm=False,
         RCVTIMEO=None,
         SNDTIMEO=None,
         ironhouse: bool = False,
-        keys_dir: str = os.path.abspath(".curve"),
+        keys_dir: t.Optional[str] = None,
         mode: str = "client",
     ):
         """
@@ -37,7 +38,8 @@ class TaskQueue:
 
         identity : str
            Applies only to clients, where the identity must match the endpoint uuid.
-           This will be utf-8 encoded on the wire. A random uuid4 string is set by default.
+           This will be utf-8 encoded on the wire. A random uuid4 string is set by
+           default.
 
         mode: string
            Either 'client' or 'server'
@@ -49,6 +51,11 @@ class TaskQueue:
            Only valid for server mode. Setting this flag switches the server to require
            client keys to be available on the server in the keys_dir.
         """
+        if identity is None:
+            identity = str(uuid.uuid4())
+        if keys_dir is None:
+            keys_dir = os.path.abspath(".curve")
+
         if zmq_context:
             self.context = zmq_context
         else:

--- a/funcx_forwarder/version.py
+++ b/funcx_forwarder/version.py
@@ -3,5 +3,5 @@
 <Major>.<Minor>.<maintenance>[alpha/beta/..]
 Alphas will be numbered like this -> 0.4.0a0
 """
-VERSION = '0.3.5'
-MIN_EP_VERSION = '0.2.1'
+VERSION = "0.3.5"
+MIN_EP_VERSION = "0.2.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,30 +1,12 @@
-[flake8]
-#
-# FIXME: remove most of these ignores
-#
-# D203: 1 blank line required before class docstring
-# E124: closing bracket does not match visual indentation
-# E126: continuation line over-indented for hanging indent
-# F405: name may be undefined, or defined from star imports: module
-# This one is bad. Sometimes ordering matters, conditional imports
-# setting env vars necessary etc.
-# E402: module level import not at top of file
-# E129: Visual indent to not match indent as next line, counter eg here:
-# https://github.com/PyCQA/pycodestyle/issues/386
-# W504: Raised by flake8 even when it is followed
-ignore = D203, E124, E126, F405, E402, E129, W504
-max-line-length = 160
-exclude = .git,.tox,__pycache__,.eggs,dist,.venv*
-# E741 disallows ambiguous single letter names which look like numbers
-# We disable it in visualization code because plotly uses 'l' as
-# a keyword arg
-# F821: undefined name
-per-file-ignores = parsl/monitoring/visualization/*:E741,
-  # needed because this deliberately has undefined names in it
-  parsl/tests/test_swift.py:F821,
-  # test_ssh_errors.py really is broken
-  parsl/tests/integration/test_channels/test_ssh_errors.py:F821
+[isort]
+profile = black
 
+[flake8]
+exclude = .git,.tox,__pycache__,dist,venv,.venv*
+# we enforce 80 char width with `black` "loosely", so flake8 should be set to
+# not fail on up to 88 chars of width
+max-line-length = 88
+ignore = W503,W504,E203
 
 [tool:pytest]
 addopts = --cov=funcx_forwarder --ignore=archived_tests

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ REQUIRES = [
     "texttable>=1.6.4,<2",
     "redis==3.5.3",
     "funcx-common[redis,boto3]==0.0.9",
-    "funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk",
-    "funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint",
+    "funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk",  # noqa: E501
+    "funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint",  # noqa: E501
     "pyzmq==22.0.3",
     "pika==1.2.0",
     "python-json-logger==2.0.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 import redis
+
 from funcx_forwarder import service
 
 

--- a/tests/test_forwarder_service.py
+++ b/tests/test_forwarder_service.py
@@ -1,4 +1,5 @@
 import pytest
+
 from funcx_forwarder import service
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,9 @@ usedevelop = true
 commands = pytest
 
 [testenv:lint]
-commands = flake8
+skip_install = true
+deps = pre-commit
+commands = pre-commit run -a
 
 [testenv:mypy]
 deps =

--- a/wait_for_redis.py
+++ b/wait_for_redis.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
 
-import redis
-import time
 import os
+import time
 
-hostname = os.environ.get('REDIS_HOST')
-port = os.environ.get('REDIS_PORT')
+import redis
+
+hostname = os.environ.get("REDIS_HOST")
+port = os.environ.get("REDIS_PORT")
 connected = False
 print(f"Attempting to connect to REDIS at {hostname}:{port}")
 for i in range(10):
     try:
-        redis_client = redis.StrictRedis(host=hostname, port=port, decode_responses=True)
+        redis_client = redis.StrictRedis(
+            host=hostname, port=port, decode_responses=True
+        )
         redis_client.ping()
     except Exception:
         print("Trying")

--- a/wait_for_redis.py
+++ b/wait_for_redis.py
@@ -9,7 +9,7 @@ hostname = os.environ.get("REDIS_HOST")
 port = os.environ.get("REDIS_PORT")
 connected = False
 print(f"Attempting to connect to REDIS at {hostname}:{port}")
-for i in range(10):
+for _i in range(10):
     try:
         redis_client = redis.StrictRedis(
             host=hostname, port=port, decode_responses=True


### PR DESCRIPTION
[sc-11988]

This is based on #49, as that allows the use of `tox -e lint` to install and run `pre-commit`.

The commits added here are, in summary
- add (but do not apply) pre-commit config
- apply pre-commit config but do not resolve flake8 issues
- resolve flake8 issues and finalize all configs