### PR TITLE
Do not use VCS dependencies

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -ex
 
-python3 -c "import funcx; print('funcx Version : ', funcx.__version__)"
 python3 -c "import funcx_endpoint; print('funcx_endpoint Version : ', funcx_endpoint.__version__)"
 python3 -c "import funcx_forwarder; print('funcx_forwarder Version : ', funcx_forwarder.__version__)"
 

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ REQUIRES = [
     "texttable>=1.6.4,<2",
     "redis==3.5.3",
     "funcx-common[redis,boto3]==0.0.11",
-    "funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk",  # noqa: E501
-    "funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint",  # noqa: E501
+    "funcx-endpoint==0.3.4",
     "pyzmq==22.0.3",
     "pika==1.2.0",
     "python-json-logger==2.0.1",


### PR DESCRIPTION
VCS dependencies result in non-reproducible builds.

Remove `funcx @ main` as a dependency. Switch `funcx-endpoint @ main` to `funcx-endpoint==0.3.4`.

---

I'm building this to test it locally now, but I don't know that the change is particularly risky. I'd understand deploying to `dev` and considering a test there sufficient.
I'll update this PR when my own testing is done.