### PR TITLE
Use get_default_task_storage from funcx-common

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REQUIRES = [
     "configobj==5.0.6",
     "texttable>=1.6.4,<2",
     "redis==3.5.3",
-    "funcx-common[redis,boto3]==0.0.9",
+    "funcx-common[redis,boto3]==0.0.10",
     "funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk",  # noqa: E501
     "funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint",  # noqa: E501
     "pyzmq==22.0.3",


### PR DESCRIPTION
Replace manual control of the task storage in this application with the default storage builder from funcx-common.

One of the consequences of this is that it becomes possible to run the forwarder without an S3 bucket. I think this is desirable for local deploys.

EDIT: I forgot to mention testing. I was able to run this version of the forwarder locally and run the new smoke tests which are in progress (the "s3 indirect" ones which use larger result sizes) successfully against it.