### PR TITLE
Updates to allow using task_storage.RedisS3 for payloads

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -435,6 +435,8 @@ class Forwarder(Process):
             logger.exception("Caught exception waiting for message from REDIS")
             return 0
 
+        task_payload = self.task_storage.get_payload(task)
+
         if dest_endpoint not in self.connected_endpoints:
             # At this point we should be unsubscribed and receiving only messages
             # from the TCP buffers.
@@ -453,7 +455,7 @@ class Forwarder(Process):
             try:
                 task_id = task.task_id
                 logger.info(f"Sending task:{task_id} to endpoint:{dest_endpoint}")
-                zmq_task = Task(task_id, task.container, task.payload)
+                zmq_task = Task(task_id, task.container, task_payload)
             except TypeError:
                 # A TypeError is raised when the Task object can't be recomposed from
                 # redis due to missing values during high-workload events.

--- a/funcx_forwarder/tasks.py
+++ b/funcx_forwarder/tasks.py
@@ -45,7 +45,7 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
     function_id = RedisField()
     endpoint = t.cast(str, RedisField())
     container = RedisField()
-    payload = RedisField()
+    payload = t.cast(t.Optional[str], RedisField(serde=JSON_SERDE))
     payload_reference = t.cast(
         t.Optional[t.Dict[str, t.Any]], RedisField(serde=JSON_SERDE)
     )

--- a/funcx_forwarder/tasks.py
+++ b/funcx_forwarder/tasks.py
@@ -45,7 +45,10 @@ class RedisTask(TaskProtocol, metaclass=HasRedisFieldsMeta):
     function_id = RedisField()
     endpoint = t.cast(str, RedisField())
     container = RedisField()
-    payload = RedisField(serde=JSON_SERDE)
+    payload = RedisField()
+    payload_reference = t.cast(
+        t.Optional[t.Dict[str, t.Any]], RedisField(serde=JSON_SERDE)
+    )
     result = t.cast(t.Optional[str], RedisField())
     result_reference = t.cast(
         t.Optional[t.Dict[str, t.Any]], RedisField(serde=JSON_SERDE)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REQUIRES = [
     "configobj==5.0.6",
     "texttable>=1.6.4,<2",
     "redis==3.5.3",
-    "funcx-common[redis,boto3]==0.0.10",
+    "funcx-common[redis,boto3]==0.0.11-a0",
     "funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk",  # noqa: E501
     "funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint",  # noqa: E501
     "pyzmq==22.0.3",

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ REQUIRES = [
     "configobj==5.0.6",
     "texttable>=1.6.4,<2",
     "redis==3.5.3",
-    "funcx-common[redis,boto3]==0.0.11-a0",
+    "funcx-common[redis,boto3]==0.0.11",
     "funcx @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk",  # noqa: E501
     "funcx-endpoint @ git+https://github.com/funcx-faas/funcX.git@main#egg=funcx-endpoint&subdirectory=funcx_endpoint",  # noqa: E501
     "pyzmq==22.0.3",


### PR DESCRIPTION
Support for storing larger payloads in S3 via RedisS3Storage.

Please note that this PR currently runs the risk of receiving tasks launched by an older version of funcx-web-service which does not follow the `payload_reference` convention expected here and cause some breakage. 

[sc-11106]