### PR TITLE
Updating result_ttl to 2 weeks from 1 hour

### DIFF
--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -5,6 +5,7 @@ import queue
 import sys
 import threading
 import time
+from datetime import timedelta
 import typing as t
 from multiprocessing import Event, Process
 
@@ -108,7 +109,7 @@ class Forwarder(Process):
         redis_port: int = 6379,
         logging_level=logging.INFO,
         heartbeat_period=30,
-        result_ttl: int = 3600,
+        result_ttl: int = int(timedelta(weeks=2).total_seconds),
         keys_dir=None,
     ):
         """

--- a/funcx_forwarder/forwarder.py
+++ b/funcx_forwarder/forwarder.py
@@ -5,8 +5,8 @@ import queue
 import sys
 import threading
 import time
-from datetime import timedelta
 import typing as t
+from datetime import timedelta
 from multiprocessing import Event, Process
 
 import pika
@@ -40,6 +40,8 @@ loglevels = {
     10: "DEBUG",
     0: "NOTSET",
 }
+
+RESULT_TTL = int(timedelta(weeks=2).total_seconds())
 
 
 class Forwarder(Process):
@@ -109,7 +111,7 @@ class Forwarder(Process):
         redis_port: int = 6379,
         logging_level=logging.INFO,
         heartbeat_period=30,
-        result_ttl: int = int(timedelta(weeks=2).total_seconds),
+        result_ttl: int = RESULT_TTL,
         keys_dir=None,
     ):
         """


### PR DESCRIPTION
I've gotten a few task-lost error reports from Eric. These tasks completed successfully and are reported as **task not found** since they are most likely removed from redis due to hitting their TTL. This PR addresses this issue by updating the TTL to 2 weeks. On a related note, it makes no sense for this timeout to be so short, and have the result be stored in S3 for a month. When the task entry in redis is gone, the s3 reference is also gone, so the S3 object won't be accessible anyway.

Here's a snippet of the error:
```
globus_sdk.exc.GlobusAPIError: (404, 'Error', '{"code":6,"error_args":["c40458a0-5726-41df-9f2f-d11c5529d752"],"http_status_code":404,"reason":"Task c40458a0-5726-41df-9f2f-d11c5529d752 not found","status":"Failed"}\n')
```

It is clear the task is complete because I see a result object in S3.