### PR TITLE
Remove the `--result_ttl` CLI option

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,12 +16,6 @@ if [[ -z "${ENDPOINT_BASE_PORT}" ]]; then
     ENDPOINT_BASE_PORT=55001
 fi
 
-if [[ -z "${RESULT_TTL_SECONDS}" ]]; then
-    RESULT_TTL_OPT=""
-else
-    RESULT_TTL_OPT="--result_ttl $RESULT_TTL_SECONDS"
-fi
-
 python3 wait_for_redis.py
 
 if [[ -z "${ADVERTISED_FORWARDER_ADDRESS}" ]]; then
@@ -31,4 +25,4 @@ if [[ -z "${ADVERTISED_FORWARDER_ADDRESS}" ]]; then
 fi
 
 
-forwarder-service -a $ADVERTISED_FORWARDER_ADDRESS -p 8080 --redishost $REDIS_HOST --redisport $REDIS_PORT --rabbitmquri $RABBITMQ_URI -d --endpoint-base-port ${ENDPOINT_BASE_PORT} $RESULT_TTL_OPT
+forwarder-service -a $ADVERTISED_FORWARDER_ADDRESS -p 8080 --redishost $REDIS_HOST --redisport $REDIS_PORT --rabbitmquri $RABBITMQ_URI -d --endpoint-base-port ${ENDPOINT_BASE_PORT}

--- a/funcx_forwarder/service.py
+++ b/funcx_forwarder/service.py
@@ -195,11 +195,6 @@ def cli_run():
         "-d", "--debug", action="store_true", help="Enables debug logging"
     )
     parser.add_argument(
-        "--result_ttl",
-        default=3600,
-        help="Set task TTL in REDIS after the result is available.",
-    )
-    parser.add_argument(
         "-v", "--version", action="store_true", help="Print version information"
     )
     parser.add_argument(
@@ -244,7 +239,6 @@ def cli_run():
         rabbitmq_conn_params,
         endpoint_ports=range(args.endpoint_base_port, args.endpoint_base_port + 3),
         logging_level=logging_level,
-        result_ttl=int(args.result_ttl),
         redis_port=args.redisport,
     )
     fw.start()


### PR DESCRIPTION
Takes precedence over the (expected) default on the `Forwarder` object. Kudos to @Loonride for spotting this!